### PR TITLE
Validation file

### DIFF
--- a/releases/1.0.1/validation/README.md
+++ b/releases/1.0.1/validation/README.md
@@ -1,0 +1,965 @@
+
+# 📚 mobilityDCAT-AP SHACL Documentation
+
+## 📖 Table of Contents
+
+### 1. Introduction
+- [What is SHACL and Why Use It?](#what-is-shacl)
+- [Why OWL is Not Enough](#why-owl-is-not-enough)
+- [Open World vs. Closed World](#open-world-vs-closed-world)
+
+### 2. Setup and Tools
+- [SHACL Playgrounds](#shacl-playgrounds)
+- [Java APIs](#java-apis)
+- [Python APIs](#python-apis)
+- [Prefixes Used](#prefixes)
+
+### 3. Shape Documentation
+- [Address Agent Shape](#address-agent-shape)
+- [Agent Shape](#agent-shape)
+- [Assessment Shape](#assessment-shape)
+- [Catalogue Shape](#catalogue-shape)
+- [CatalogRecord Shape](#catalogrecord-shape)
+- [Category Shape](#category-shape)
+- [Dataset Shape](#dataset-shape)
+- [Distribution Shape](#distribution-shape)
+- [Kind Shape](#kind-shape)
+- [LicenseDocument Shape](#licensedocument-shape)
+- [Location Shape](#location-shape)
+- [MobilityDataStandard Shape](#mobilitydatastandard-shape)
+- [QualityAnnotation Shape](#qualityannotation-shape)
+- [RightsStatement Shape](#rightsstatement-shape)
+
+### 4. Resources
+- [Validation Tools](#validation-tools)
+- [External References](#external-references)
+- [Additional Documentation](#additional-documentation)
+
+Would you like me to continue with any specific section or expand this outline further?
+
+
+
+
+# 🔍 Introduction to SHACL
+
+## 🎯 What is SHACL and Why Use It?
+
+SHACL (Shapes Constraint Language) is a language for validating RDF graphs against a set of conditions. It is used to:
+
+1. Define the structure of RDF data
+2. Validate RDF data against predefined shapes
+3. Data quality assurance
+
+## 🔄 Why OWL is Not Enough
+
+While OWL (Web Ontology Language) is powerful for defining ontologies and inferring new knowledge, it has limitations:
+
+1. OWL operates under the Open World Assumption, making it challenging to validate data completeness
+2. OWL lacks built-in support for certain validation tasks, like cardinality checks on properties
+3. OWL is designed for inferencing, not for data validation
+
+SHACL complements OWL by providing a robust framework specifically for data validation and integrity constraints.
+
+## 🌐 Open World vs. Closed World
+For a detailed technical explanation of these concepts, see: [Open World vs. Closed World Assumptions in Knowledge Representation](https://www.sciencedirect.com/topics/computer-science/open-world-assumption)
+
+1. **Open World Assumption (OWA)**:
+   - Used in OWL
+   - Assumes that what is not explicitly stated might be true
+   - Good for knowledge representation and inferencing
+   - Challenging for data validation
+
+2. **Closed World Assumption (CWA)**:
+   - Used in SHACL
+   - Assumes that what is not explicitly stated is false
+   - Better suited for data validation and constraint checking
+   - Allows for more stringent data quality control
+
+SHACL's use of CWA makes it more appropriate for scenarios where you need to ensure data completeness and adherence to a specific structure.
+
+## 💡 Key Takeaway
+
+SHACL provides a standardized, powerful way to validate RDF data, filling gaps left by OWL and other Semantic Web technologies. Its closed-world approach makes it particularly useful for ensuring data quality and completeness in various applications, from data integration.
+
+
+# 🔍 SHACL Basics (Core) and Advanced Features
+
+## 🌱 SHACL Basics (Core Features)
+
+SHACL Core provides the fundamental constraints and validation mechanisms. Here are the key components, for more detail see: [Core Constraint Components](https://www.w3.org/TR/shacl/#core-components)
+
+1. **Node Shapes**
+   - Define constraints that apply to nodes in the data graph.
+   - Example: `sh:NodeShape` to define a shape for a specific class of nodes.
+
+2. **Property Shapes**
+   - Define constraints on properties and their values.
+   - Example: `sh:PropertyShape` to define constraints on a specific property.
+
+3. **Cardinality Constraints**
+   - Control the number of values a property can have.
+   - Examples: `sh:minCount`, `sh:maxCount`
+
+4. **Value Type Constraints**
+   - Specify the allowed types for property values.
+   - Examples: `sh:datatype`, `sh:class`, `sh:nodeKind`
+
+5. **Value Range Constraints**
+   - Define allowed ranges for numeric and date values.
+   - Examples: `sh:minInclusive`, `sh:maxExclusive`
+
+6. **String Constraints**
+   - Constrain string values using patterns or length.
+   - Examples: `sh:pattern`, `sh:minLength`, `sh:maxLength`
+
+7. **Logical Constraints**
+   - Combine constraints using logical operators.
+   - Examples: `sh:and`, `sh:or`, `sh:not`
+
+8. **Shape References**
+   - Reference other shapes within a shape definition.
+   - Example: `sh:node` to reference another shape
+
+9. **Targeting Rules**
+   - Specify which nodes in the data graph a shape applies to.
+   - Examples: `sh:targetClass`, `sh:targetNode`
+
+10. **Result Properties**
+    - Customize validation result messages.
+    - Example: `sh:message` for custom violation messages
+
+## 📝 Notes
+
+- SHACL Core is sufficient for many common validation scenarios and is widely supported.
+- SHACL Advanced features provide more flexibility but may have limited support in some tools.
+- When using advanced features, consider compatibility with your chosen SHACL engine.
+- Combining multiple features can create powerful validation rules but may also increase complexity.
+- Always test your shapes thoroughly, especially when using advanced features, to ensure they behave as expected.
+
+Remember, while SHACL Advanced offers powerful capabilities, it's often best to start with SHACL Core and only use advanced features when necessary for your specific use case.
+
+
+# 📚 SHACL Shape Prefixes
+
+This document lists the prefixes used in the SHACL shapes for the [mobilityDCAT-AP](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html) Application Profile.
+
+| Prefix | IRI |
+|--------|-----|
+| : | `http://w3id.org/mobilitydcat-ap#` |
+| mobilitydcatap | `http://w3id.org/mobilitydcat-ap#` |
+| adms | `http://www.w3.org/ns/adms#` |
+| bibo | `http://purl.org/ontology/bibo/` |
+| cnt | `http://www.w3.org/2011/content#` |
+| dcat | `http://www.w3.org/ns/dcat#` |
+| dcatap | `http://data.europa.eu/r5r/` |
+| dct | `http://purl.org/dc/terms/` |
+| dqv | `http://www.w3.org/ns/dqv#` |
+| foaf | `http://xmlns.com/foaf/0.1/` |
+| org | `http://www.w3.org/ns/org#` |
+| locn | `http://www.w3.org/ns/locn#` |
+| vcard | `http://www.w3.org/2006/vcard/ns#` |
+| owl | `http://www.w3.org/2002/07/owl#` |
+| rdf | `http://www.w3.org/1999/02/22-rdf-syntax-ns#` |
+| oa | `http://www.w3.org/ns/oa#` |
+| skos | `http://www.w3.org/2004/02/skos/core#` |
+| rdfs | `http://www.w3.org/2000/01/rdf-schema#` |
+| sh | `http://www.w3.org/ns/shacl#` |
+| xsd | `http://www.w3.org/2001/XMLSchema#` |
+
+## 📝 Notes
+
+- The `:` prefix and `mobilitydcatap` prefix both refer to the same IRI (`http://w3id.org/mobilitydcat-ap#`). This is likely for convenience, allowing both a shorthand (`:`) and a more descriptive prefix for the same namespace.
+- These prefixes cover a wide range of vocabularies and standards used in semantic web technologies, including:
+  - DCAT (Data Catalog Vocabulary)
+  - Dublin Core Terms
+  - FOAF (Friend of a Friend)
+  - SKOS (Simple Knowledge Organization System)
+  - OWL (Web Ontology Language)
+  - SHACL (Shapes Constraint Language)
+  - XML Schema
+- Some prefixes are specific to certain domains or applications, such as `bibo` for bibliographic ontology and `vcard` for contact information.
+
+## 🔧 Usage
+
+When working with SHACL shapes or RDF data using these vocabularies, you can use these prefixes to shorten IRIs. For example, instead of writing:
+
+```turtle
+<http://w3id.org/mobilitydcat-ap#someProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+```
+
+You can write:
+
+```turtle
+mobilitydcatap:someProperty rdf:type owl:ObjectProperty .
+```
+
+This makes the data more readable and easier to manage.
+
+# 🛠️ SHACL Playgrounds and APIs
+Here's the reformatted version with cleaner links:
+
+## 🎮 SHACL Playgrounds
+SHACL playgrounds are online tools that allow you to experiment with SHACL shapes and validate RDF data without needing to set up a local environment.
+1. **TopBraid SHACL Playground** [Try it ↗](https://shacl.org/playground/)
+   - Features: Allows testing SHACL shapes against data graphs, provides detailed violation reports.
+2. **RDFShape** [Try it ↗](https://rdfshape.weso.es/shaclValidate)
+   - Features: Supports SHACL and ShEx validation, data conversion, and visualization.
+3. **SHACL Play** [Try it ↗](https://shacl-play.sparna.fr/play/)
+   - Features: Offers a user-friendly interface for SHACL validation and shape creation.
+4. **Zazuko SHACL Playground** [Try it ↗](https://shacl-playground.zazuko.com/)
+   - Features: Simple interface for SHACL validation, good for quick tests.
+
+## 💻 Java APIs for SHACL
+1. **Apache Jena SHACL** [Learn more ↗](https://jena.apache.org/documentation/shacl/)
+   - Features: Part of the Apache Jena framework, offers comprehensive SHACL support.
+2. **TopBraid SHACL API** [GitHub ↗](https://github.com/TopQuadrant/shacl)
+   - Features: The reference implementation of SHACL, very complete and well-maintained.
+3. **RDF4J SHACL** [Documentation ↗](https://rdf4j.org/documentation/programming/shacl/)
+   - Features: SHACL support as part of the RDF4J framework.
+
+## 🐍 Python APIs for SHACL
+1. **pySHACL** [GitHub ↗](https://github.com/RDFLib/pySHACL)
+   - Features: A Python implementation of SHACL, built on top of RDFLib.
+2. **Pyshacl** [PyPI ↗](https://pypi.org/project/pyshacl/)
+   - Features: SHACL validator for Python, available via pip.
+
+## 📝 Notes
+
+- When choosing a tool or API, consider factors such as:
+  - Ease of use and integration with your existing workflow
+  - Performance, especially for large datasets
+  - Compliance with the latest SHACL specification
+  - Community support and documentation
+
+- For production use, it's often best to use a well-established library like Apache Jena (Java) or pySHACL (Python).
+
+- Online playgrounds are great for quick tests and learning, but for sensitive data or large-scale validation, a local implementation is usually more appropriate.
+
+- Some of these tools may have additional features beyond basic SHACL validation, such as inference support or integration with other semantic web technologies.
+
+
+
+# 🛠️ SHACL Playground Guide for mobilityDCAT-AP
+
+## 🌐 Accessing SHACL Playground
+
+1. Go to [https://shacl.org/playground/](https://shacl.org/playground/)
+
+## 📚 Using mobilityDCAT-AP Resources
+
+### 📐 Shapes Graph
+
+Load mobilityDCAT-AP SHACL shapes:
+
+[https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/mobilitydcat-ap_shacl_shapes.ttl](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/mobilitydcat-ap_shacl_shapes.ttl)
+
+### 📊 Data Graph
+
+Find example data graphs here:
+
+[https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#examples](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#examples)
+
+## ✅ Validation
+
+The playground automatically validates the data against the shapes.
+
+---
+
+# mobilityDCAT-AP SHACL Shapes:
+
+# 📜 :Address_Agent_Shape
+The `:Address_Agent_Shape` is a SHACL node shape that defines the structure and constraints for the `locn:Address` class. This shape ensures that instances of address information for agents have the necessary properties and conform to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `locn:Address`
+- **Name**: "Address (Agent)" (in English)
+
+## 📝 Properties
+### 1. Administrative Area 🏛️
+- **Path**: `locn:adminUnitL2`
+- **Cardinality**: Maximum 1 (Recommended)
+- **Type**: Literal
+- **Name**: "administrative area"
+- **Description**: The administrative area of an Address of the Agent. Depending on the country, this corresponds to a province, a county, a region, or a state.
+- **Severity**: Violation
+
+### 2. City 🌆
+- **Path**: `locn:postName`
+- **Cardinality**: Maximum 1 (Recommended)
+- **Type**: Literal
+- **Name**: "city"
+- **Description**: The city of an Address of the Agent.
+- **Severity**: Violation
+
+### 3. Country 🌍
+- **Path**: `locn:adminUnitL1`
+- **Cardinality**: Maximum 1 (Recommended)
+- **Type**: Literal
+- **Name**: "country"
+- **Description**: The country of an Address of the Agent.
+- **Severity**: Violation
+
+### 4. Postal Code 📮
+- **Path**: `locn:postCode`
+- **Cardinality**: Maximum 1 (Recommended)
+- **Type**: Literal
+- **Name**: "postal code"
+- **Description**: The postal code of an Address of the Agent.
+- **Severity**: Violation
+
+### 5. Street Address 🏠
+- **Path**: `locn:thoroughfare`
+- **Cardinality**: Maximum 1 (Recommended)
+- **Type**: Literal
+- **Name**: "street address"
+- **Description**: In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have a severity level of "Violation" if constraints are not met
+- Each property is limited to a maximum of one value
+- All values must be literals
+- All properties are recommended (not mandatory)
+
+# 📜 :Agent_Shape Documentation
+The `:Agent_Shape` is a SHACL node shape that defines the structure and constraints for the `foaf:Agent` class. This shape ensures that agent information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `foaf:Agent`
+- **Name**: "Agent" (in English)
+
+## 📝 Properties
+### 1. Address 📍
+- **Path**: `locn:address`
+- **Type**: `locn:Address`
+- **Value Type**: Literal
+- **Name**: "address"
+- **Description**: This property MAY be used to specify the postal address of the Agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].
+- **Severity**: Violation
+
+### 2. Affiliation 🏢
+- **Path**: `org:memberOf`
+- **Type**: `org:Organization`
+- **Name**: "affiliation"
+- **Description**: If the agent is of type person, this property SHOULD be used to specify the affiliation of the Agent, see § 7. Agent Types, Agent Roles and Contact Information. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].
+- **Severity**: Violation
+
+### 3. Email 📧
+- **Path**: `foaf:mbox`
+- **Value Type**: IRI
+- **Name**: "email"
+- **Description**: This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent.
+- **Severity**: Violation
+
+### 4. First Name 👤
+- **Path**: `foaf:firstName`
+- **Cardinality**: Maximum 1
+- **Data Type**: `sh:Literal`
+- **Name**: "first name"
+- **Description**: If the agent is of type person, this property SHOULD be used to specify the first name of the Agent, see section § 7. Agent Types, Agent Roles and Contact Information.
+- **Severity**: Violation
+
+### 5. Phone ☎️
+- **Path**: `foaf:phone`
+- **Value Type**: Literal
+- **Name**: "phone"
+- **Description**: This property MAY be used to provide the phone number of the Agent, specified using fully qualified tel: URI scheme [RFC3966]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].
+- **Severity**: Violation
+
+### 6. Surname 👥
+- **Path**: `foaf:surname`
+- **Cardinality**: Maximum 1
+- **Data Type**: `xsd:string`
+- **Name**: "surname"
+- **Description**: If the agent is of type person, this property SHOULD be used to specify the surname of the Agent, see section 7.
+- **Severity**: Violation
+
+### 7. work place Homepage URL 🌐
+- **Path**: `foaf:workplaceHomepage`
+- **Cardinality**: Maximum 1
+- **Type**: `rdfs:Resource`
+- **Name**: "work place Homepage URL"
+- **Description**: If the agent is of type person, this property SHOULD be used to specify the surname of the Agent, see section 7.
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have a severity level of "Violation" if constraints are not met
+- First name, surname, and URL are limited to a maximum of one value
+- Email must be an IRI (mailto: scheme)
+- Phone numbers should use the tel: URI scheme
+- All properties are optional but recommended when applicable
+
+# 📜 :Assessment_Shape
+The `:Assessment_Shape` is a SHACL node shape that defines the structure and constraints for the `mobilitydcatap:Assessment` class. This shape ensures that assessment information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `mobilitydcatap:Assessment`
+- **Name**: "Assessment"
+
+## 📝 Properties
+### 1. Assessment Date 📅
+- **Path**: `dct:issued`
+- **Cardinality**: Maximum 1 (Optional)
+- **Data Type**: Either `xsd:date` OR `xsd:dateTime`
+- **Name**: "assessment date"
+- **Description**: This property MAY be used to describe the date of the latest assessment procedure.
+- **Severity**: Violation
+
+### 2. Assessment Result 📊
+- **Path**: `oa:hasBody`
+- **Cardinality**: Maximum 1 (Optional)
+- **Type**: `rdfs:Resource`
+- **Name**: "assessment result"
+- **Description**: This property MAY be used to describe the result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes.
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- Both properties have a severity level of "Violation" if constraints are not met
+- Both properties are limited to a maximum of one value
+-  Both properties are optional
+- Assessment date must be either a date or datetime value
+- Assessment result must be a resource (typically a URL or embedded text)
+
+## 📌 Notes
+- The assessment result can be provided either as:
+  - A URL linking to detailed results
+  - Embedded textual information with language specifications
+- Date values must conform to either:
+  - XML Schema date format (YYYY-MM-DD)
+  - XML Schema dateTime format (YYYY-MM-DDThh:mm:ss)
+ 
+# 📜 :Catalogue_Shape 
+The `:Catalogue_Shape
+` is a SHACL node shape that defines the structure and constraints for the `dcat:Catalog` class. This shape ensures that catalogue information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `dcat:Catalog`
+- **Name**: "Catalogue" (in English)
+
+## 📝 Properties
+### 1. Primary Identifier 🔑
+- **Path**: `dct:identifier`
+- **Cardinality**: Maximum 1 (Optional)
+- **Value Type**: Literal
+- **Name**: "identifier"
+- **Description**: This property MAY contain an identifier for the mobility data portal. Allows a unique identification of the individual portal and is used for referencing, e.g., when exchanging metadata between mobility data portals. This property SHOULD populated by the URI used within the RDF statement (via rdf:about). This property is analogue to an addition by [GEODCAT-AP-v2.0.0].
+- **Severity**: Violation
+
+### 2. Other Identifier 🏷️
+- **Path**: `adms:identifier`
+- **Cardinality**: Maximum 1 (Optional)
+- **Type**: `adms:Identifier`
+- **Name**: "other identifier"
+- **Description**: This property MAY be used as an additional identifier, besides dct:identifier. It MAY be referring to a dedicated, EU-wide identificator system of NAPS or other portals, to be introduced in the future.
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- Both properties have a severity level of "Violation" if constraints are not met
+- Both properties are limited to a maximum of one value
+- Primary identifier must be a literal value
+- Other identifier must be of type `adms:Identifier`
+
+# 📜 :CatalogRecord_Shape
+The `:CatalogRecord_Shape
+` is a SHACL node shape that defines the structure and constraints for the `dcat:CatalogRecord` class. This shape ensures that catalogue record information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `dcat:CatalogRecord`
+- **Name**: "Catalogue Record" 
+
+## 📝 Properties
+### 1. Creation Date ⏰
+- **Path**: `dct:created`
+- **Cardinality**: Exactly 1 (Mandatory)
+- **Data Type**: Either `xsd:date` OR `xsd:dateTime`
+- **Name**: "creation date"
+- **Description**: This property contains the date stamp (date and time) when the metadata entry was created for the first time. It SHOULD be generated by the system, whenever a platform user enters the metadata entry.
+- **Severity**: Violation
+
+### 2. Publisher 👥
+- **Path**: `dct:publisher`
+- **Cardinality**: Maximum 1 (Optional)
+- **Type**: `foaf:Agent`
+- **Name**: "publisher"
+- **Description**: This property refers to an entity (an organisation or a person), which is responsible for creation and maintenance of the metadata entry on the data platform. This entity is the direct contact for the data platform operators or data-searching users, who have questions or issues about the metadata entry. This information can be natively created by a data platform, then corresponding to the entity that is registered to the data platform and has the role of a metadata creator. This information can be also harvested from other portals. It should include, as a minimum, the name and email address of the entity. The information might be identical to the property "Publisher" of the corresponding dataset. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- Both properties have a severity level of "Violation" if constraints are not met
+- Creation date:
+  - Must be present (minimum count: 1)
+  - Must appear exactly once (maximum count: 1)
+  - Must be either a date or datetime value
+- Publisher:
+  - Optional (no minimum count)
+  - Maximum one publisher allowed
+  - Must be of type `foaf:Agent`
+
+## 🔧 Usage
+When creating or validating a Catalogue Record:
+1. ⏰ Must include exactly one creation date:
+   - Use either date (YYYY-MM-DD) or
+   - DateTime (YYYY-MM-DDThh:mm:ss) format
+   - Should be system-generated
+
+# 📜 :Category_Shape
+The `:Category_Shape
+` is a SHACL node shape that defines the structure and constraints for the `skos:Concept` class. This shape ensures that category information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `skos:Concept`
+- **Name**: "Category" (in English)
+
+## 📝 Properties
+### 1. Category Scheme 🗂️
+- **Path**: `skos:inScheme`
+- **Cardinality**: Maximum 1 (Optional)
+- **Type**: `skos:ConceptScheme`
+- **Name**: "category scheme"
+- **Description**: This property MAY be used to specify the Category Scheme to which the Category belongs. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- The property has a severity level of "Violation" if constraints are not met
+- Category scheme is limited to a maximum of one value
+- Must be of type `skos:ConceptScheme`
+
+## 🔧 Usage
+When creating or validating a Category:
+1. 🗂️ Optionally include one category scheme:
+   - Specifies the broader classification system
+   - Links the category to its parent scheme
+
+# 📜 Dataset Shape Documentation
+## 📋 Overview
+The `Dataset_Shape` is a SHACL node shape that defines the structure and constraints for the `dcat:Dataset` class. This shape ensures that dataset information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `dcat:Dataset`
+- **Name**: "Dataset" (in English)
+
+## 📝 Properties
+
+### 1. Mobility Theme 🚦 (Mandatory)
+- **Path**: `mobilitydcatap:mobilityTheme`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/mobility-theme"
+- **Minimum Count**: 1
+- **Name**: "mobility theme"
+- **Description**: Refers to mobility-related theme of content. Requires hierarchical categorization with mandatory first level and optional second level.
+- **Severity**: Violation
+
+### 2. Georeferencing Method 🗺️ (Recommended)
+- **Path**: `mobilitydcatap:georeferencingMethod`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/georeferencing-method"
+- **Name**: "georeferencing method"
+- **Description**: Should specify the georeferencing method used in the dataset.
+- **Severity**: Violation
+
+### 3. Network Coverage 🌐 (Recommended)
+- **Path**: `mobilitydcatap:networkCoverage`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/network-coverage"
+- **Name**: "network coverage"
+- **Description**: Describes covered transport network parts, particularly for road traffic.
+- **Severity**: Violation
+
+### 4. Reference System 📍 (Recommended)
+- **Path**: `dct:conformsTo`
+- **Pattern**: Must match "http://www.opengis.net/def/crs/EPSG/0/"
+- **Name**: "reference system"
+- **Description**: Should specify spatial reference system using EPSG URIs.
+- **Severity**: Violation
+
+### 5. Rights Holder 👤 (Recommended)
+- **Path**: `dct:rightsHolder`
+- **Type**: `foaf:Agent`
+- **Name**: "rights holder"
+- **Description**: Entity legally owning or holding data rights.
+- **Severity**: Violation
+
+### 6. Transport Mode 🚗 (Recommended)
+- **Path**: `mobilitydcatap:transportMode`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/transport-mode"
+- **Name**: "transport mode"
+- **Description**: Describes covered transport modes (multiple possible).
+- **Severity**: Violation
+
+### 7. Applicable Legislation ⚖️ (Optional)
+- **Path**: `dcatap:applicableLegislation`
+- **Type**: `skos:Concept`
+- **Name**: "applicable legislation"
+- **Description**: References relevant legal frameworks.
+- **Severity**: Violation
+
+### 8. Assessment Result 📊 (Optional)
+- **Path**: `mobilitydcatap:assessmentResult`
+- **Type**: `mobilitydcatap:Assessment`
+- **Maximum Count**: 1
+- **Name**: "assessment result"
+- **Description**: References assessment process results.
+- **Severity**: Violation
+
+### 9. Intended Information Service ℹ️ (Optional)
+- **Path**: `mobilitydcatap:intentedInformationService`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/intended-information-service"
+- **Name**: "intended information service"
+- **Description**: Describes predefined information services the data supports.
+- **Severity**: Violation
+
+### 10. Quality Description ✅ (Optional)
+- **Path**: `dqv:hasQualityAnnotation`
+- **Type**: `dqv:QualityAnnotation`
+- **Name**: "quality description"
+- **Description**: Describes quality aspects of the content.
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have violation severity
+- Mobility Theme is mandatory (minimum 1)
+- Assessment Result limited to maximum 1
+- All other properties are either recommended or optional
+
+# 📜  :Distribution_Shape
+The ` :Distribution_Shape
+` is a SHACL node shape that defines the structure and constraints for the `dcat:Distribution` class. This shape ensures that distribution information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `dcat:Distribution`
+- **Name**: "Distribution"
+
+## 📝 Properties
+
+### 1. Mobility Data Standard 📊 (Mandatory)
+- **Path**: `mobilitydcatap:mobilityDataStandard`
+- **Type**: `mobilitydcatap:MobilityDataStandard`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/mobility-data-standard"
+- **Cardinality**: Exactly 1 (Mandatory)
+- **Name**: "mobility data standard"
+- **Description**: Describes the mobility data standard used for content delivery (e.g., DATEX II).
+- **Severity**: Violation
+
+### 2. Application Layer Protocol 🔄 (Recommended)
+- **Path**: `mobilitydcatap:applicationLayerProtocol`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/application-layer-protocol"
+- **Maximum Count**: 1
+- **Name**: "application layer protocol"
+- **Description**: Describes the transmitting channel of the distribution.
+- **Severity**: Violation
+
+### 3. Character Encoding 📝 (Optional)
+- **Path**: `cnt:characterEncoding`
+- **Type**: `sh:Literal`
+- **Maximum Count**: 1
+- **Name**: "character encoding"
+- **Description**: Specifies the technical encoding format via character set standard.
+- **Severity**: Violation
+
+### 4. Communication Method 🔁 (Optional)
+- **Path**: `mobilitydcatap:communicationMethod`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/communication-method"
+- **Maximum Count**: 1
+- **Name**: "communication method"
+- **Description**: Indicates push or pull mode for data services.
+- **Severity**: Violation
+
+### 5. Data Format Notes 📋 (Optional)
+- **Path**: `mobilitydcatap:dataFormatNotes`
+- **Type**: `sh:Literal`
+- **Maximum Count**: 1
+- **Name**: "data format notes"
+- **Description**: Additional textual information about content format.
+- **Severity**: Violation
+
+### 6. Grammar 📖 (Optional)
+- **Path**: `mobilitydcatap:grammar`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/grammar"
+- **Maximum Count**: 1
+- **Name**: "grammar"
+- **Description**: Describes technical data grammar format as sub-property of dct:conformsTo.
+- **Severity**: Violation
+
+### 7. Sample 🔍 (Optional)
+- **Path**: `adms:sample`
+- **Type**: `rdfs:Resource`
+- **Name**: "sample"
+- **Description**: References a sample distribution of the dataset.
+- **Severity**: Violation
+
+### 8. Temporal Coverage ⏱️ (Optional)
+- **Path**: `dct:temporal`
+- **Type**: `dct:PeriodOfTime`
+- **Maximum Count**: 1
+- **Name**: "temporal coverage"
+- **Description**: Specifies time interval for data service delivery.
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have violation severity
+- Mobility Data Standard:
+  - Mandatory (exactly one required)
+  - Must follow specific URI pattern
+- Other properties:
+  - Most have maximum count of 1
+  - Must follow specified patterns where applicable
+
+# 📜 :Kind_Shape
+
+The `:Kind_Shape` is a SHACL node shape that defines the structure and constraints for the `vcard:Kind` class. This shape ensures that contact information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `vcard:Kind`
+- **Name**: "Kind" (in English)
+
+## 📝 Properties
+
+### 1. Email 📧 (Mandatory)
+- **Path**: `vcard:hasEmail`
+- **Minimum Count**: 1
+- **Value Type**: IRI
+- **Pattern**: Must start with "mailto:" (case-insensitive)
+- **Name**: "email"
+- **Description**: Contains email address using mailto: URI scheme [RFC6068].
+- **Severity**: Violation
+- **Message**: "Email must be a valid mailto: URI"
+
+### 2. Name 👤 (Mandatory)
+- **Path**: `vcard:fn`
+- **Value Type**: Literal
+- **Minimum Count**: 1
+- **Name**: "name"
+- **Description**: Contains name of the Kind. Can be repeated for different languages.
+- **Severity**: Violation
+
+### 3. URL 🌐 (Recommended)
+- **Path**: `vcard:hasURL`
+- **Maximum Count**: 1
+- **Name**: "URL"
+- **Description**: Points to a Web site of the Kind.
+- **Severity**: Violation
+
+### 4. Address 📫 (Optional)
+- **Path**: `vcard:hasAddress`
+- **Type**: `vcard:Address`
+- **Maximum Count**: 1
+- **Name**: "address"
+- **Description**: Specifies the postal address of the Kind.
+- **Severity**: Violation
+
+### 5. Affiliation 🏢 (Optional)
+- **Path**: `vcard:organization-name`
+- **Value Type**: Literal
+- **Maximum Count**: 1
+- **Name**: "affiliation"
+- **Description**: Specifies the affiliation. Can be repeated for different languages.
+- **Severity**: Violation
+
+### 6. Phone ☎️ (Optional)
+- **Path**: `vcard:hasTelephone`
+- **Maximum Count**: 1
+- **Name**: "phone"
+- **Description**: Provides phone number using tel: URI scheme [RFC3966].
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have violation severity
+- Mandatory properties:
+  - Email (must have at least one)
+  - Name (must have at least one)
+- Maximum one instance for:
+  - URL
+  - Address
+  - Affiliation
+  - Phone
+- Email must follow mailto: URI scheme
+- Phone must follow tel: URI scheme
+
+# 📜 :LicenseDocument_Shape
+The `:LicenseDocument_Shape` is a SHACL node shape that defines the structure and constraints for the `dct:LicenseDocument` class. This shape ensures that license information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `dct:LicenseDocument`
+- **Name**: "License Document" (in English)
+
+## 📝 Properties
+
+### 1. Standard License 📄 (Recommended)
+- **Path**: `dct:identifier`
+- **Pattern**: Must match "http://publications.europa.eu/resource/authority/access-right"
+- **Maximum Count**: 1
+- **Name**: "standard licence"
+- **Description**: Used to link to a concrete standard license.
+- **Severity**: Violation
+
+### 2. License Text 📝 (Optional)
+- **Path**: `rdfs:label`
+- **Value Type**: Literal
+- **Maximum Count**: 1
+- **Name**: "licence text"
+- **Description**: Contains the full text of a License Document as free text. Can be used when no standard license is available. Supports multiple language versions.
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have violation severity
+- Both properties limited to maximum of one instance
+- Standard License must follow specified URI pattern
+- License Text must be a literal value
+
+# 📜 :Location_Shape
+The `:Location_Shape` is a SHACL node shape that defines the structure and constraints for the `dct:Location` class. This shape ensures that location information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `dct:Location`
+- **Name**: "Location" (in English)
+
+## 📝 Properties
+
+### 1. Gazetteer 🗺️ (Recommended)
+- **Path**: `skos:inScheme`
+- **Type**: `skos:ConceptScheme`
+- **Maximum Count**: 1
+- **Name**: "gazetteer"
+- **Description**: Specifies the gazetteer to which the Location belongs.
+- **Severity**: Violation
+
+### 2. Geographic Identifier 📍 (Recommended)
+- **Path**: `dct:identifier`
+- **Value Type**: Either Literal OR IRI
+- **Name**: "geographic identifier"
+- **Description**: Contains the geographic identifier for the Location, e.g., the URI or other unique identifier in the context of the relevant gazetteer.
+- **Severity**: Violation
+
+### 3. Geographic Name 🏷️ (Optional)
+- **Path**: `skos:prefLabel`
+- **Value Type**: Literal
+- **Name**: "geographic name"
+- **Description**: Contains a preferred label of the Location. Can be repeated for different language versions.
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have violation severity
+- Gazetteer is limited to maximum of one instance
+- Geographic Identifier must be either a Literal or IRI
+- Geographic Name must be a literal value
+
+# 📜  :MobilityDataStandard_Shape
+The ` :MobilityDataStandard_Shape` is a SHACL node shape that defines the structure and constraints for the `mobilitydcatap:mobilityDataStandard` class. This shape ensures that mobility data standard information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `mobilitydcatap:mobilityDataStandard`
+- **Name**: "Mobility Data Standard" (in English)
+
+## 📝 Properties
+
+### 1. Version Number 🔢 (Optional)
+- **Path**: `owl:versionInfo`
+- **Value Type**: Literal
+- **Maximum Count**: 1
+- **Name**: "version"
+- **Description**: Describes the version of the mobility data standard used in the content (e.g., "3.2" for DATEX II v3.2). Should use concise version identifiers without redundant prefixes.
+- **Severity**: Violation
+
+### 2. Schema Reference 📋 (Optional)
+- **Path**: `mobilitydcatap:schema`
+- **Type**: `rdfs:Resource`
+- **Maximum Count**: 1
+- **Name**: "schema"
+- **Description**: References the schema of the mobility data standard. Can point to:
+  - Portal-internal schema catalogue
+  - Individual publisher-provided schema
+  - External schema catalogue (e.g., DATEX II profile)
+- Sub-property of dct:conformsTo
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have violation severity
+- Both properties limited to maximum of one instance
+- Version must be a literal value
+- Schema must be a resource reference
+
+# 📜 :QualityAnnotation_Shape
+The `:QualityAnnotation_Shape` is a SHACL node shape that defines the structure and constraints for the `dqv:QualityAnnotation` class. This shape ensures that quality annotation information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `dqv:QualityAnnotation`
+- **Name**: "Quality Annotation" (in English)
+
+## 📝 Properties
+
+### 1. Quality Annotation Resource ✅ (Optional)
+- **Path**: `oa:hasBody`
+- **Value Type**: Literal
+- **Maximum Count**: 1
+- **Name**: "quality annotation resource"
+- **Description**: Describes quality aspects through either:
+  - URL linking to detailed information
+  - Embedded textual information with language specifications
+- Supports Web Annotation Data Model format
+- **Severity**: Violation
+
+### 2. Quality Annotation Target 🎯 (Optional)
+- **Path**: `oa:hasTarget`
+- **Type**: `dcat:Dataset`
+- **Maximum Count**: 1
+- **Name**: "quality annotation target"
+- **Description**: References the target dataset being described. Acts as inverse property of "dqv:hasQualityAnnotation" for Dataset class.
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- All properties have violation severity
+- Both properties limited to maximum of one instance
+- Quality Annotation Resource must be a literal value
+- Quality Annotation Target must reference a Dataset
+
+# 📜 Rights Statement Shape Documentation
+## 📋 Overview
+The `RightsStatement_Shape` is a SHACL node shape that defines the structure and constraints for the `dct:RightsStatement` class. This shape ensures that rights statement information has the necessary properties and conforms to specified rules.
+
+## 📊 Shape Details
+- **Type**: `sh:NodeShape`
+- **Target Class**: `dct:RightsStatement`
+- **Name**: "Rights Statement" (in English)
+
+## 📝 Properties
+
+### 1. Conditions for Access and Usage 🔒 (Mandatory)
+- **Path**: `dct:type`
+- **Pattern**: Must match "https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage"
+- **Cardinality**: Exactly 1 (Mandatory)
+- **Name**: "conditions for access and usage"
+- **Description**: Indicates whether:
+  - Free and unrestricted use is possible
+  - Contract must be concluded
+  - License must be agreed upon
+- **Severity**: Violation
+
+### 2. Additional Information ℹ️ (Recommended)
+- **Path**: `rdfs:label`
+- **Value Type**: Literal
+- **Name**: "Additional information for access and usage"
+- **Description**: Provides supplementary textual information about:
+  - Access conditions
+  - Usage requirements
+  - Licensing details
+- Supports multiple language versions
+- **Severity**: Violation
+
+## ⚠️ Constraints
+- Both properties have violation severity
+- Conditions for Access and Usage:
+  - Mandatory (exactly one required)
+  - Must follow specific URI pattern
+- Additional Information:
+  - Must be literal value
+  - Can have multiple language versions

--- a/releases/1.0.1/validation/README.md
+++ b/releases/1.0.1/validation/README.md
@@ -1,45 +1,6 @@
 
 # 📚 mobilityDCAT-AP SHACL Documentation
 
-## 📖 Table of Contents
-
-### 1. Introduction
-- [What is SHACL and Why Use It?](#what-is-shacl)
-- [Why OWL is Not Enough](#why-owl-is-not-enough)
-- [Open World vs. Closed World](#open-world-vs-closed-world)
-
-### 2. Setup and Tools
-- [SHACL Playgrounds](#shacl-playgrounds)
-- [Java APIs](#java-apis)
-- [Python APIs](#python-apis)
-- [Prefixes Used](#prefixes)
-
-### 3. Shape Documentation
-- [Address Agent Shape](#address-agent-shape)
-- [Agent Shape](#agent-shape)
-- [Assessment Shape](#assessment-shape)
-- [Catalogue Shape](#catalogue-shape)
-- [CatalogRecord Shape](#catalogrecord-shape)
-- [Category Shape](#category-shape)
-- [Dataset Shape](#dataset-shape)
-- [Distribution Shape](#distribution-shape)
-- [Kind Shape](#kind-shape)
-- [LicenseDocument Shape](#licensedocument-shape)
-- [Location Shape](#location-shape)
-- [MobilityDataStandard Shape](#mobilitydatastandard-shape)
-- [QualityAnnotation Shape](#qualityannotation-shape)
-- [RightsStatement Shape](#rightsstatement-shape)
-
-### 4. Resources
-- [Validation Tools](#validation-tools)
-- [External References](#external-references)
-- [Additional Documentation](#additional-documentation)
-
-Would you like me to continue with any specific section or expand this outline further?
-
-
-
-
 # 🔍 Introduction to SHACL
 
 ## 🎯 What is SHACL and Why Use It?

--- a/releases/1.0.1/validation/address_agent_shape.ttl
+++ b/releases/1.0.1/validation/address_agent_shape.ttl
@@ -1,0 +1,64 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Scenarios Based on the SHACL Shape
+# the only potential invalid scenarios are:
+# Correct Example (All Properties Present)
+:CologneHistoricalDistrictAddress a locn:Address ;
+    locn:adminUnitL2 "Nordrhein-Westfalen" ;
+    locn:postName "Köln" ;
+    locn:adminUnitL1 "Deutschland" ;
+    locn:postCode "50667" ;
+    locn:thoroughfare "Hohe Straße 85" .
+
+:CologneEigelsteinQuarterAddress a locn:Address ;
+    locn:adminUnitL2 "Nordrhein-Westfalen"^^xsd:string ;
+    locn:postName "Köln"^^xsd:string ;
+    locn:adminUnitL1 "Deutschland"^^xsd:string ;
+    locn:postCode "50668"^^xsd:string ;
+    locn:thoroughfare "Eigelstein 115"^^xsd:string .
+
+# Multiple Values: Any property having more than one value (due to sh:maxCount 1).
+# Incorrect Data Type: Any property value not being of the type a literal.
+# Example 1: Multiple values violation
+:MunichCityHallAddressInvalid1 a locn:Address ;
+    locn:adminUnitL2 "Bavaria", "Saxony" ; # Invalid: Multiple values
+    locn:postName "Munich" ;
+    locn:adminUnitL1 "Germany" ;
+    locn:postCode "80331" ;
+    locn:thoroughfare "Marienplatz 8" .
+
+# Example 2: Non-literal values violation
+:MunichCityHallAddressInvalid2 a locn:Address ;
+    locn:adminUnitL2 <http://example.org/Bavaria> ; # Invalid: Not a literal
+    locn:postName "Munich" ;
+    locn:adminUnitL1 "Germany" ;
+    locn:postCode 80331 ; # Invalid: Not a string literal
+    locn:thoroughfare "Marienplatz 8" .
+
+# Example 3: Blank node violation
+:MunichCityHallAddressInvalid3 a locn:Address ;
+    locn:adminUnitL2 [ a skos:Concept ; skos:prefLabel "Bavaria" ] ; # Invalid: Blank node
+    locn:postName "Munich" ;
+    locn:adminUnitL1 "Germany" ;
+    locn:postCode "80331" ;
+    locn:thoroughfare "Marienplatz 8" .

--- a/releases/1.0.1/validation/agent_shape.ttl
+++ b/releases/1.0.1/validation/agent_shape.ttl
@@ -1,0 +1,146 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Research Organization
+:FraunhoferFIT a org:Organization ;
+    foaf:name "Fraunhofer Institute for Applied Information Technology FIT" .
+
+<https://www.fit.fraunhofer.de/> a rdfs:Resource .
+
+# Institute Address
+:SchlossResearchCampus a locn:Address ;
+    locn:adminUnitL2 "Nordrhein-Westfalen" ;
+    locn:postName "Sankt Augustin" ;
+    locn:adminUnitL1 "Deutschland" ;
+    locn:postCode "53757" ;
+    locn:thoroughfare "Schloss Birlinghoven" .
+
+# Research Scientist Profile
+:DrThomasSchmidt a foaf:Agent ;
+    locn:address :SchlossResearchCampus ;
+    org:memberOf :FraunhoferFIT ;
+    foaf:mbox <mailto:thomas.schmidt@fit.fraunhofer.de> ;
+    foaf:firstName "Thomas" ;
+    foaf:surname "Schmidt" ;
+    foaf:phone "tel:+492241141" ;
+    foaf:workplaceHomepage <https://www.fit.fraunhofer.de/> .
+    
+     
+
+# Example 1: Invalid address specification (using literal instead of resource)
+:BerlinUniversityResearcher a foaf:Agent ;
+    locn:address "Unter den Linden 6, 10117 Berlin" ; # Value is a literal string but must be an instance of locn:Address class and Value is a literal string but must be either a blank node or IRI (sh:BlankNodeOrIRI)
+    org:memberOf :HumboldtUniversity ;                # :HumboldtUniversity needs to be explicitly declared as org:Organization
+    foaf:mbox <mailto:researcher@hu-berlin.de> ;
+    foaf:firstName "Anna" ;
+    foaf:surname "Schmidt" ;
+    foaf:phone "tel:+493020932000" ;
+    foaf:workplaceHomepage <https://www.hu-berlin.de> . # <https://www.hu-berlin.de> needs to be explicitly declared as rdfs:Resource
+
+
+# Corrected Version:
+:HumboldtUniversity a org:Organization ;  
+    foaf:name "Humboldt-Universität zu Berlin" .
+
+<https://www.hu-berlin.de> a rdfs:Resource . 
+
+:BerlinAddress a locn:Address ;  
+    locn:thoroughfare "Unter den Linden 6" ;
+    locn:postCode "10117" ;
+    locn:postName "Berlin" ;
+    locn:adminUnitL2 "Berlin" ;
+    locn:adminUnitL1 "Deutschland" .
+
+:BerlinUniversityResearcher a foaf:Agent ;
+    locn:address :BerlinAddress ;
+    org:memberOf :HumboldtUniversity ;
+    foaf:mbox <mailto:researcher@hu-berlin.de> ;
+    foaf:firstName "Anna" ;
+    foaf:surname "Schmidt" ;
+    foaf:phone "tel:+493020932000" ;
+    foaf:workplaceHomepage <https://www.hu-berlin.de> .
+
+
+# Example 2: Invalid organization reference
+:MunichTechAddress a locn:Address ;
+    locn:thoroughfare "Arcisstraße 21" ;
+    locn:postCode "80333" ;
+    locn:postName "München" ;
+    locn:adminUnitL2 "Bayern" ;
+    locn:adminUnitL1 "Deutschland" .
+
+:MunichDataScientist a foaf:Agent ;
+    locn:address :MunichTechAddress ;
+    org:memberOf "TU Munich Data Lab" ; # Invalid: should be an org:Organization instance
+    foaf:mbox <mailto:scientist@tum.de> ;
+    foaf:firstName "Max" ;
+    foaf:surname "Weber" ;
+    foaf:phone "tel:+498921800" ;
+    foaf:workplaceHomepage <https://www.tum.de> . # needs to be explicitly declared as rdfs:Resource
+
+
+# Example 3: Invalid email format
+:HamburgPortAddress a locn:Address ;
+    locn:thoroughfare "Bei St. Annen 1" ;
+    locn:postCode "20457" ;
+    locn:postName "Hamburg" ;
+    locn:adminUnitL2 "Hamburg" ;
+    locn:adminUnitL1 "Deutschland" .
+
+:HamburgPort a org:Organization ;  
+    foaf:name "HamburgPort" .
+
+<https://www.hamburg-port.de> a rdfs:Resource .
+
+:HamburgEngineer a foaf:Agent ;
+    locn:address :HamburgPortAddress ;
+    org:memberOf :HamburgPort ;
+    foaf:mbox "engineer@hamburg-port.de" ; # Invalid: should be mailto: URI
+    foaf:firstName "Lars" ;
+    foaf:surname "Fischer" ;
+    foaf:phone "tel:+494042847-0" ;
+    foaf:workplaceHomepage <https://www.hamburg-port.de> .
+
+# Example 4: Multiple first names violation
+
+:FrankfurtFinanceAddress a locn:Address ;
+    locn:thoroughfare "Taunusanlage 12" ;
+    locn:postCode "60325" ;
+    locn:postName "Frankfurt am Main" ;
+    locn:adminUnitL2 "Hessen" ;
+    locn:adminUnitL1 "Deutschland" .
+:DeutscheBank a org:Organization ;  
+    foaf:name "DeutscheBank" . 
+ <https://www.db.com> a rdfs:Resource .
+     
+:FrankfurtBanker a foaf:Agent ;
+    locn:address :FrankfurtFinanceAddress ;
+    org:memberOf :DeutscheBank ;
+    foaf:mbox <mailto:banker@db.com> ;
+    foaf:firstName "Thomas" ;
+    foaf:firstName "Tom" ; # Invalid: violates maxCount 1
+    foaf:surname "Müller" ;
+    foaf:phone "tel:+496991010" ;
+    foaf:workplaceHomepage <https://www.db.com> .
+
+
+

--- a/releases/1.0.1/validation/assessment_shape.ttl
+++ b/releases/1.0.1/validation/assessment_shape.ttl
@@ -1,0 +1,77 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Fraunhofer Traffic Flow Dataset with Assessment
+:FraunhoferTrafficDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data> ;
+    mobilitydcatap:georeferencingMethod <https://w3id.org/mobilitydcat-ap/georeferencing-method/linear-referencing> ;
+    mobilitydcatap:networkCoverage <https://w3id.org/mobilitydcat-ap/network-coverage/federal-roads> ;
+    dct:conformsTo <http://www.opengis.net/def/crs/EPSG/0/25832> ;
+    dct:rightsHolder [
+        a foaf:Agent ;
+        foaf:name "Fraunhofer FIT - ITS Research Division" ;
+        foaf:mbox <mailto:traffic.data@fit.fraunhofer.de>
+    ] ;
+    mobilitydcatap:transportMode <https://w3id.org/mobilitydcat-ap/transport-mode/road> ;
+    dcatap:applicableLegislation <http://data.europa.eu/eli/reg_del/2015/962/oj> ;
+    mobilitydcatap:assessmentResult :TrafficFlowAssessment ;
+    mobilitydcatap:intentedInformationService <https://w3id.org/mobilitydcat-ap/intended-information-service/real-time-traffic> ;
+    dqv:hasQualityAnnotation [
+        a dqv:QualityAnnotation ;
+        dqv:inDimension dqv:Availability ;
+        dct:description "Traffic flow data updated every 3 minutes, with 99.5% data completeness and accuracy validation through floating car data"@en
+    ] .
+
+# Associated Assessment
+:TrafficFlowAssessment a mobilitydcatap:Assessment ;
+    dct:issued "2024-03-15T14:30:00"^^xsd:dateTime ;
+    oa:hasBody <https://data.mobility.fraunhofer.de/assessments/traffic-flow-2024-03> .
+
+<https://data.mobility.fraunhofer.de/assessments/traffic-flow-2024-03> a rdfs:Resource .
+
+
+
+# Invalid Examples with Assessment
+
+# Invalid: Multiple Assessment Results
+:InvalidTrafficDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data> ;
+    mobilitydcatap:assessmentResult :TrafficFlowAssessment ;
+    mobilitydcatap:assessmentResult :AdditionalAssessment . # *Invalid: Multiple assessments violate maxCount 1*
+
+:AdditionalAssessment a mobilitydcatap:Assessment ;
+    dct:issued "2024-03-16T10:00:00"^^xsd:dateTime ;
+    oa:hasBody <https://data.mobility.fraunhofer.de/assessments/traffic-flow-2024-03-update> .
+
+# Invalid: Assessment Result Not Properly Typed
+:InvalidAssessmentDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data> ;
+    mobilitydcatap:assessmentResult "Passed Quality Check" . # *Invalid: Should be mobilitydcatap:Assessment*
+
+# Invalid: Assessment Without Required Resource Declaration
+:IncompleteAssessmentDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data> ;
+    mobilitydcatap:assessmentResult [
+        a mobilitydcatap:Assessment ;
+        dct:issued "2024-03-15"^^xsd:date ;
+        oa:hasBody <https://data.mobility.fraunhofer.de/assessments/incomplete> # *Invalid: Resource not declared*
+    ] .

--- a/releases/1.0.1/validation/catalog_record_shape.ttl
+++ b/releases/1.0.1/validation/catalog_record_shape.ttl
@@ -1,0 +1,64 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Valid Records
+
+# Fraunhofer FIT Data Platform Record
+:FITCatalogRecord a dcat:CatalogRecord ;
+    dct:created "2024-03-15T10:30:00"^^xsd:dateTime ;
+    dct:publisher :FraunhoferFITDataTeam .
+
+:FraunhoferFITDataTeam a foaf:Agent, org:Organization ;
+    foaf:name "Fraunhofer FIT Data Management Team" ;
+    foaf:mbox <mailto:mobility.data@fit.fraunhofer.de> .
+
+# City of Cologne Traffic Data Record
+:CologneTrafficRecord a dcat:CatalogRecord ;
+    dct:created "2024-03-14"^^xsd:date ;
+    dct:publisher :CologneDataManager .
+
+:CologneDataManager a foaf:Agent, foaf:Person ;
+    foaf:name "Dr. Lisa Mueller" ;
+    foaf:mbox <mailto:lisa.mueller@stadt-koeln.de> .
+
+# Invalid Records
+
+# Multiple Publishers Error
+:BonnTransitRecord a dcat:CatalogRecord ;
+    dct:created "2024-03-13"^^xsd:date ;
+    dct:publisher :BonnTransitAuthority ; # *Invalid: Multiple publishers*
+    dct:publisher :BonnDataTeam .
+
+:BonnTransitAuthority a foaf:Agent .
+:BonnDataTeam a foaf:Agent .
+
+# Non-Agent Publisher
+:DusseldorfTrafficRecord a dcat:CatalogRecord ;
+    dct:created "2024-03-15"^^xsd:date ;
+    dct:publisher "City of Düsseldorf" . # *Invalid: Not a foaf:Agent instance*
+
+# Wrong Type Publisher
+:AachenParkingRecord a dcat:CatalogRecord ;
+    dct:created "2024-03-15"^^xsd:date ;
+    dct:publisher :AachenParkingSystem .
+
+:AachenParkingSystem a dcat:Dataset . # *Invalid: Not a foaf:Agent*

--- a/releases/1.0.1/validation/catalogue_shape.ttl
+++ b/releases/1.0.1/validation/catalogue_shape.ttl
@@ -1,0 +1,68 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Valid Catalogs
+
+# Aachen Mobility Data Catalog
+:AachenMobilityCatalog a dcat:Catalog ;
+    dct:identifier "Aachen-MOB-2024" ;
+    adms:identifier [
+        a adms:Identifier ;
+        skos:notation "EU-NAP-DE-Aachen-2024"
+    ] .
+
+# City of Cologne Transport Data Catalog
+:CologneMobilityCatalog a dcat:Catalog ;
+    dct:identifier "KOELN-MOB-2024" .
+
+# NRW Regional Transport Data Catalog
+:NRWTransportCatalog a dcat:Catalog ;
+    adms:identifier [
+        a adms:Identifier ;
+        skos:notation "EU-NAP-DE-NRW-2024"
+    ] .
+
+# Invalid Catalogs
+
+# Invalid: Non-literal identifier
+:DusseldorfMobilityCatalog a dcat:Catalog ;
+    dct:identifier <https://mobility.duesseldorf.de/catalog> . # *Invalid: Must be literal*
+
+# Invalid: Multiple identifiers
+:BonnTransportCatalog a dcat:Catalog ;
+    dct:identifier "BONN-MOB-2024" ; # *Invalid: Multiple identifiers violate maxCount 1*
+    dct:identifier "BONN-TRANSPORT-2024" .
+
+# Invalid: Wrong identifier type
+:AachenMobilityCatalog a dcat:Catalog ;
+    adms:identifier "NAP-DE-AC-2024" . # *Invalid: Must be adms:Identifier instance*
+
+# Invalid: Multiple ADMS identifiers
+:RuhrRegionCatalog a dcat:Catalog ;
+    adms:identifier [ # *Invalid: Multiple ADMS identifiers violate maxCount 1*
+        a adms:Identifier ;
+        skos:notation "EU-NAP-DE-RUHR-2024-A"
+    ] ;
+    adms:identifier [
+        a adms:Identifier ;
+        skos:notation "EU-NAP-DE-RUHR-2024-B"
+    ] .

--- a/releases/1.0.1/validation/category_shape.ttl
+++ b/releases/1.0.1/validation/category_shape.ttl
@@ -1,0 +1,71 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Valid Category Schemes
+:EUMobilityTaxonomy a skos:ConceptScheme ;
+    rdfs:label "European Urban Mobility Taxonomy"@en ;
+    dct:description "Standard classification scheme for urban mobility data in European cities"@en .
+
+:GermanNAPCategories a skos:ConceptScheme ;
+    rdfs:label "German NAP Data Categories"@en ;
+    dct:description "Official categorization scheme for the German National Access Point"@en .
+
+# Valid Categories
+
+# Public Transport Category with EU Scheme
+:PublicTransportCategory a skos:Concept ;
+    skos:prefLabel "Public Transport"@en ;
+    skos:prefLabel "Öffentlicher Verkehr"@de ;
+    skos:inScheme :EUMobilityTaxonomy .
+
+# Shared Mobility Category with German NAP Scheme
+:SharedMobilityCategory a skos:Concept ;
+    skos:prefLabel "Shared Mobility"@en ;
+    skos:prefLabel "Geteilte Mobilität"@de ;
+    skos:inScheme :GermanNAPCategories .
+
+# Traffic Management Category (without scheme - valid as scheme is optional)
+:TrafficManagementCategory a skos:Concept ;
+    skos:prefLabel "Traffic Management"@en ;
+    skos:prefLabel "Verkehrsmanagement"@de .
+
+# Invalid Categories
+
+# Invalid: Multiple Schemes
+:ParkingCategory a skos:Concept ;
+    skos:prefLabel "Parking"@en ;
+    skos:prefLabel "Parken"@de ;
+    skos:inScheme :EUMobilityTaxonomy ; # *Invalid: Multiple schemes violate maxCount 1*
+    skos:inScheme :GermanNAPCategories .
+
+# Invalid: Wrong Scheme Type
+:ChargingStationCategory a skos:Concept ;
+    skos:prefLabel "Charging Infrastructure"@en ;
+    skos:prefLabel "Ladeinfrastruktur"@de ;
+    skos:inScheme :InvalidScheme . # *Invalid: Target is not a skos:ConceptScheme*
+
+:InvalidScheme a skos:Concept . # Should be skos:ConceptScheme
+
+# Invalid: Literal Instead of Resource
+:BikeInfrastructureCategory a skos:Concept ;
+    skos:prefLabel "Cycling Infrastructure"@en ;
+    skos:prefLabel "Fahrradinfrastruktur"@de ;
+    skos:inScheme "European Mobility Categories" . # *Invalid: Must be a resource, not a literal*

--- a/releases/1.0.1/validation/dataset_shape.ttl
+++ b/releases/1.0.1/validation/dataset_shape.ttl
@@ -1,0 +1,113 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Cologne Traffic Dataset
+:CologneTrafficDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/traffic-data> ;
+    mobilitydcatap:georeferencingMethod <https://w3id.org/mobilitydcat-ap/georeferencing-method/linear-referencing> ;
+    mobilitydcatap:networkCoverage <https://w3id.org/mobilitydcat-ap/network-coverage/urban-roads> ;
+    dct:conformsTo <http://www.opengis.net/def/crs/EPSG/0/25832> ;
+    dct:rightsHolder [
+        a foaf:Agent ;
+        foaf:name "Stadt Köln - Amt für Verkehrsmanagement" ;
+        foaf:mbox <mailto:verkehrsmanagement@stadt-koeln.de>
+    ] ;
+    mobilitydcatap:transportMode <https://w3id.org/mobilitydcat-ap/transport-mode/road> ;
+    dcatap:applicableLegislation <http://data.europa.eu/eli/reg_del/2015/962/oj> ;
+    mobilitydcatap:assessmentResult [
+        a mobilitydcatap:Assessment ;
+        dct:description "Compliant with EU RTTI Delegated Regulation standards"@en
+    ] ;
+    mobilitydcatap:intentedInformationService <https://w3id.org/mobilitydcat-ap/intended-information-service/real-time-traffic> ;
+    dqv:hasQualityAnnotation [
+        a dqv:QualityAnnotation ;
+        dqv:inDimension dqv:Availability ;
+        dct:description "Traffic data update frequency: Every 5 minutes, 98.5% system availability"@en
+    ] ;
+    dqv:hasQualityAnnotation [
+        a dqv:QualityAnnotation ;
+        oa:hasBody """KVB Real-time Data Quality Report:
+        - Real-time arrival predictions available for 97% of stops
+        - Update frequency: 30 seconds
+        - Average prediction accuracy: ±2 minutes
+        - Service disruption reporting within 60 seconds
+        For detailed reports visit: https://opendata.cologne.de/dataset/kvb-realtime-quality"""@en ;
+        oa:hasTarget :CologneTransitDataset
+    ] .
+
+# Cologne Transit Dataset with mandatory properties
+:CologneTransitDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/public-transport> ; # Added mandatory theme
+    mobilitydcatap:georeferencingMethod <https://w3id.org/mobilitydcat-ap/georeferencing-method/stop-point> ;
+    mobilitydcatap:transportMode <https://w3id.org/mobilitydcat-ap/transport-mode/bus>,
+                                <https://w3id.org/mobilitydcat-ap/transport-mode/tram> ;
+    dct:rightsHolder [
+        a foaf:Agent ;
+        foaf:name "Kölner Verkehrs-Betriebe AG" ;
+        foaf:mbox <mailto:opendata@kvb.koeln>
+    ] .
+
+:HamburgPortDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/freight-transport> ;
+    dqv:hasQualityAnnotation [
+        a dqv:QualityAnnotation ;
+        dqv:inDimension dqv:Availability ;
+        dct:description "High quality real-time data with 99.9% availability"@en
+    ] .
+
+# Invalid Examples
+
+# Düsseldorf Parking Dataset - Missing Mandatory Theme
+:DusseldorfParkingDataset a dcat:Dataset ;
+    mobilitydcatap:georeferencingMethod <https://w3id.org/mobilitydcat-ap/georeferencing-method/point-based> ;
+    dct:conformsTo <http://www.opengis.net/def/crs/EPSG/0/25832> .
+
+# Bonn Public Transport Dataset - Wrong Theme Pattern
+:BonnPTDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <http://example.org/public-transport> ; # *Invalid pattern*
+    mobilitydcatap:transportMode <https://w3id.org/mobilitydcat-ap/transport-mode/bus> .
+
+# Frankfurt Bike Sharing Dataset - Multiple Assessments
+:FrankfurtBikeDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/shared-mobility> ;
+    mobilitydcatap:assessmentResult [
+        a mobilitydcatap:Assessment ;
+        dct:description "First Quarter Assessment 2024"@en
+    ] ;
+    mobilitydcatap:assessmentResult [ # *Invalid: Multiple assessments*
+        a mobilitydcatap:Assessment ;
+        dct:description "Second Quarter Assessment 2024"@en
+    ] .
+
+# Aachen E-Charging Dataset - Invalid Rights Holder
+:AachenChargingDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/charging-infrastructure> ;
+    dct:rightsHolder "City of Aachen" . # *Invalid: Should be foaf:Agent*
+
+
+
+# Invalid 
+:InvalidHamburgPortDataset a dcat:Dataset ;
+    mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/freight-transport> ;
+    dqv:hasQualityAnnotation "High quality real-time data" . # Invalid because:
+                                                            # 1. It's a literal string
+                                                            # 2. Should be an instance of dqv:QualityAnnotation

--- a/releases/1.0.1/validation/distribution_shape.ttl
+++ b/releases/1.0.1/validation/distribution_shape.ttl
@@ -1,0 +1,96 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Valid Distribution Examples
+
+# Cologne Real-time Traffic Data Distribution
+:CologneTrafficDistribution a dcat:Distribution ;
+    mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex2> ;
+    mobilitydcatap:applicationLayerProtocol <https://w3id.org/mobilitydcat-ap/application-layer-protocol/mqtt> ;
+    cnt:characterEncoding "UTF-8" ;
+    mobilitydcatap:communicationMethod <https://w3id.org/mobilitydcat-ap/communication-method/push> ;
+    mobilitydcatap:dataFormatNotes "DATEX II v3.3 with urban traffic extensions"@en ;
+    mobilitydcatap:grammar <https://w3id.org/mobilitydcat-ap/grammar/xml> ;
+    adms:sample <https://open.nrw/cologne/traffic/sample> ;
+    dct:temporal [
+        a dct:PeriodOfTime ;
+        dct:start "2024-01-01T00:00:00Z"^^xsd:dateTime
+    ] .
+
+# NRW Regional Transit GTFS Feed Distribution
+:NRWRegionalTransitGTFSDistribution a dcat:Distribution ;
+    mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/gtfs> ;
+    mobilitydcatap:applicationLayerProtocol <https://w3id.org/mobilitydcat-ap/application-layer-protocol/https> ;
+    cnt:characterEncoding "UTF-8" ;
+    mobilitydcatap:communicationMethod <https://w3id.org/mobilitydcat-ap/communication-method/pull> ;
+    mobilitydcatap:dataFormatNotes "GTFS Realtime feed for NRW regional transit with live occupancy data for trains and buses"@en ;
+    mobilitydcatap:grammar <https://w3id.org/mobilitydcat-ap/grammar/protobuf> ;
+    adms:sample <https://mobility.fraunhofer.de/nrw-transit/gtfs/sample> ;
+    dct:temporal [
+        a dct:PeriodOfTime ;
+        dct:start "2024-03-01T00:00:00Z"^^xsd:dateTime ;
+        dct:end "2024-12-31T23:59:59Z"^^xsd:dateTime
+    ] .
+
+# Valid Distribution with Temporal Coverage
+:ValidDistribution a dcat:Distribution ;
+    mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex2> ;
+    dct:temporal [
+        a dct:PeriodOfTime ;  # Must be explicitly typed as dct:PeriodOfTime
+        dct:start "2024-01-01T00:00:00Z"^^xsd:dateTime ;
+        dct:end "2024-12-31T23:59:59Z"^^xsd:dateTime
+    ] .
+
+# Using Named Time Period IRI
+:NRWTransitDistribution a dcat:Distribution ;
+    mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/gtfs> ;
+    dct:temporal <https://mobility.fraunhofer.de/temporal/2024-annual> .
+
+<https://mobility.fraunhofer.de/temporal/2024-annual> a dct:PeriodOfTime ;
+    dct:start "2024-01-01T00:00:00Z"^^xsd:dateTime ;
+    dct:end "2024-12-31T23:59:59Z"^^xsd:dateTime .
+
+# Invalid Examples
+
+:InvalidDistribution4 a dcat:Distribution ;
+    mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex2> ;
+    dct:temporal "2024-01-01/2024-12-31" . # Invalid because:
+                                          # 1. It's a literal string, not a dct:PeriodOfTime instance
+                                          # 2. Doesn't have proper start and end dates
+                                          # 3. Missing proper dateTime format with timezone
+
+# Missing Mandatory Standard
+:InvalidDistribution1 a dcat:Distribution ;
+    mobilitydcatap:applicationLayerProtocol <https://w3id.org/mobilitydcat-ap/application-layer-protocol/http> .
+    # *Invalid: Missing mandatory mobilityDataStandard*
+
+# Invalid Pattern for Standard
+:InvalidDistribution2 a dcat:Distribution ;
+    mobilitydcatap:mobilityDataStandard <http://example.org/standards/datex> ; # *Invalid: Wrong pattern*
+    mobilitydcatap:applicationLayerProtocol <https://w3id.org/mobilitydcat-ap/application-layer-protocol/http> .
+
+# Multiple Character Encodings
+:InvalidDistribution3 a dcat:Distribution ;
+    mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex2> ;
+    cnt:characterEncoding "UTF-8", # *Invalid: Multiple encodings violate maxCount 1*
+                         "ASCII" .
+

--- a/releases/1.0.1/validation/kind_shape.ttl
+++ b/releases/1.0.1/validation/kind_shape.ttl
@@ -1,0 +1,88 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Valid Contacts
+
+
+
+# Cologne Traffic Management Contact
+:CologneTrafficContact a vcard:Kind ;
+    vcard:hasEmail <mailto:verkehrsmanagement@stadt-koeln.de> ;
+    vcard:fn "Amt für Verkehrsmanagement"@de,
+             "Office of Traffic Management"@en ;
+    vcard:hasURL <https://www.stadt-koeln.de/verkehr> ;
+    vcard:hasAddress [
+        a vcard:Address ;
+        vcard:street-address "Willy-Brandt-Platz 2" ;
+        vcard:postal-code "50679" ;
+        vcard:locality "Köln" ;
+        vcard:country-name "Deutschland"
+    ] ;
+    vcard:organization-name "Stadt Köln"@de ; # Only one organization name allowed
+    vcard:hasTelephone <tel:+4922122123333> .
+
+# Invalid Examples
+
+:InvalidCologneTrafficContact a vcard:Kind ;
+    vcard:hasEmail <mailto:verkehrsmanagement@stadt-koeln.de> ;
+    vcard:fn "Amt für Verkehrsmanagement"@de,
+             "Office of Traffic Management"@en ;
+    vcard:hasURL <https://www.stadt-koeln.de/verkehr> ;
+    vcard:hasAddress [
+        a vcard:Address ;
+        vcard:street-address "Willy-Brandt-Platz 2" ;
+        vcard:postal-code "50679" ;
+        vcard:locality "Köln" ;
+        vcard:country-name "Deutschland"
+    ] ;
+    vcard:organization-name "Stadt Köln"@de, # *Invalid: Multiple values violate maxCount 1*
+                          "City of Cologne"@en ;
+    vcard:hasTelephone <tel:+4922122123333> .
+
+# Missing Mandatory Email
+:InvalidMobilityContact1 a vcard:Kind ;
+    vcard:fn "NRW Transport Data Team" ; # *Invalid: Missing mandatory email*
+    vcard:organization-name "Verkehrsverbund Rhein-Ruhr" .
+
+# Invalid Email Format
+:InvalidMobilityContact2 a vcard:Kind ;
+    vcard:hasEmail "mobility@example.com" ; # *Invalid: Not a mailto: URI*
+    vcard:fn "Regional Mobility Team" .
+
+# Multiple URLs
+:InvalidMobilityContact3 a vcard:Kind ;
+    vcard:hasEmail <mailto:info@mobility.de> ;
+    vcard:fn "Mobility Services" ;
+    vcard:hasURL <https://mobility.de>, # *Invalid: Multiple URLs violate maxCount 1*
+                <https://mobility.de/contact> .
+
+# Invalid Address Format
+:InvalidMobilityContact4 a vcard:Kind ;
+    vcard:hasEmail <mailto:contact@transport.de> ;
+    vcard:fn "Transport Data Team" ;
+    vcard:hasAddress "Hauptstraße 1, Berlin" . # *Invalid: Should be vcard:Address instance*
+
+# Multiple Phone Numbers
+:InvalidMobilityContact5 a vcard:Kind ;
+    vcard:hasEmail <mailto:support@traffic.de> ;
+    vcard:fn "Traffic Management Support" ;
+    vcard:hasTelephone <tel:+49301234567>, # *Invalid: Multiple phones violate maxCount 1*
+                      <tel:+49301234568> .

--- a/releases/1.0.1/validation/license_document_shape.ttl
+++ b/releases/1.0.1/validation/license_document_shape.ttl
@@ -1,0 +1,61 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Valid License Documents
+
+# Public EU Open Data License
+:EUOpenDataLicense a dct:LicenseDocument ;
+    dct:identifier <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+    rdfs:label "This dataset is provided under the EU Open Data License. Free to use with attribution to the data provider."@en .
+
+# Fraunhofer Research Data License
+:FraunhoferResearchLicense a dct:LicenseDocument ;
+    dct:identifier <http://publications.europa.eu/resource/authority/access-right/NON_PUBLIC> ;
+    rdfs:label "For research and academic use only. Contact Fraunhofer FIT for commercial usage rights."@en .
+
+# Custom Municipal Data License
+:CologneOpenDataLicense a dct:LicenseDocument ;
+    rdfs:label "Diese Daten werden unter der Datenlizenz Deutschland – Namensnennung – Version 2.0 bereitgestellt. Siehe: www.govdata.de/dl-de/by-2-0"@de .
+
+# Invalid Examples
+
+# Invalid: Wrong Pattern for Identifier
+:InvalidMobilityLicense1 a dct:LicenseDocument ;
+    dct:identifier <https://creativecommons.org/licenses/by/4.0/> ; # *Invalid: Wrong identifier pattern*
+    rdfs:label "Creative Commons Attribution 4.0 International License"@en .
+
+# Invalid: Multiple Identifiers
+:InvalidMobilityLicense2 a dct:LicenseDocument ;
+    dct:identifier <http://publications.europa.eu/resource/authority/access-right/PUBLIC>, # *Invalid: Multiple identifiers*
+                  <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> ;
+    rdfs:label "Mixed Access License"@en .
+
+# Invalid: Multiple Labels
+:InvalidMobilityLicense3 a dct:LicenseDocument ;
+    dct:identifier <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+    rdfs:label "Public Transport Data License"@en, # *Invalid: Multiple labels*
+              "Lizenz für ÖPNV-Daten"@de .
+
+# Invalid: Non-literal Label
+:InvalidMobilityLicense4 a dct:LicenseDocument ;
+    dct:identifier <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+    rdfs:label <http://example.org/license-text> . # *Invalid: Label must be literal*

--- a/releases/1.0.1/validation/location_shape.ttl
+++ b/releases/1.0.1/validation/location_shape.ttl
@@ -1,0 +1,76 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Valid Gazetteers
+:GermanMunicipalityRegister a skos:ConceptScheme ;
+    rdfs:label "Official German Municipality Directory"@en,
+              "Amtliches Gemeindeverzeichnis Deutschland"@de .
+
+:EUNUTSRegions a skos:ConceptScheme ;
+    rdfs:label "European NUTS Classification"@en,
+              "Europäische NUTS-Klassifikation"@de .
+
+# Valid Location Examples
+
+# Cologne City Location
+:CologneLocation a dct:Location ;
+    skos:inScheme :GermanMunicipalityRegister ;
+    dct:identifier "05315000" ; # Official German municipality code
+    skos:prefLabel "Köln"@de,
+                  "Cologne"@en,
+                  "Colonia"@es .
+
+# North Rhine-Westphalia NUTS Region
+:NRWLocation a dct:Location ;
+    skos:inScheme :EUNUTSRegions ;
+    dct:identifier <http://data.europa.eu/nuts/code/DEA> ;
+    skos:prefLabel "Nordrhein-Westfalen"@de,
+                  "North Rhine-Westphalia"@en .
+
+# Minimal Example for Sankt Augustin
+:SanktAugustinLocation a dct:Location ;
+    dct:identifier "05382060" . # Official municipality code
+
+# Invalid Examples
+
+# Multiple Gazetteer References
+:InvalidBonnLocation a dct:Location ;
+    skos:inScheme :GermanMunicipalityRegister ; # *Invalid: Multiple schemes*
+    skos:inScheme :EUNUTSRegions ;
+    dct:identifier "05314000" ;
+    skos:prefLabel "Bonn"@de .
+
+# Non-literal Label
+:InvalidDusseldorfLocation a dct:Location ;
+    skos:inScheme :GermanMunicipalityRegister ;
+    dct:identifier "05111000" ;
+    skos:prefLabel <http://example.com/city/duesseldorf> . # *Invalid: Must be literal*
+
+# Invalid Gazetteer Type
+:InvalidAachenLocation a dct:Location ;
+    skos:inScheme "German Cities" ; # *Invalid: Must be skos:ConceptScheme*
+    dct:identifier "05334002" ;
+    skos:prefLabel "Aachen"@de .
+
+# Location Without Recommended Identifier
+:IncompleteEssenLocation a dct:Location ;
+    skos:inScheme :GermanMunicipalityRegister ;
+    skos:prefLabel "Essen"@de . # *Missing recommended dct:identifier*

--- a/releases/1.0.1/validation/mobility_data_standard_shape.ttl
+++ b/releases/1.0.1/validation/mobility_data_standard_shape.ttl
@@ -1,0 +1,119 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+
+# Valid and Invalid Examples for MobilityDataStandard_Shape
+
+# Valid Example 1: Both properties present and valid
+# Explanation for Valid Example 1:
+# This example is valid because:
+# 1. It has the correct class (mobilitydcatap:mobilityDataStandard).
+# 2. The owl:versionInfo is a literal with a short version identifier.
+# 3. The mobilitydcatap:schema is a resource (:Schema1) that is explicitly typed as rdfs:Resource.
+# 4. Both properties appear only once.
+:ValidStandard1 a mobilitydcatap:mobilityDataStandard ;
+    owl:versionInfo "3.2" ;
+    mobilitydcatap:schema :Schema1 .
+
+:Schema1 a rdfs:Resource .
+
+
+
+# Valid Example 2: Only version property present
+# Explanation for Valid Example 2:
+# This example is valid because:
+# 1. It has the correct class.
+# 2. The owl:versionInfo is a valid literal.
+# 3. The schema property is optional and can be omitted.
+:ValidStandard2 a mobilitydcatap:mobilityDataStandard ;
+    owl:versionInfo "2.0" .
+
+
+
+# Valid Example 3: Only schema property present
+# Explanation for Valid Example 3:
+# This example is valid because:
+# 1. It has the correct class.
+# 2. The mobilitydcatap:schema is a valid resource URI.
+# 3. The version property is optional and can be omitted.
+
+:ValidStandard3 a mobilitydcatap:mobilityDataStandard ;
+    mobilitydcatap:schema <http://datex2.eu/profiles/urban-traffic> .
+
+
+# Invalid Example 1: Multiple version properties
+ex:InvalidStandard1 a mobilitydcatap:mobilityDataStandard ;
+    owl:versionInfo "3.2" ;
+    owl:versionInfo "3.3" ;
+    mobilitydcatap:schema <http://example.org/schemas/datex2> .
+
+# Explanation for Invalid Example 1:
+# This example is invalid because:
+# 1. It has multiple owl:versionInfo properties, violating the sh:maxCount 1 constraint.
+
+# Invalid Example 2: Invalid version format
+ex:InvalidStandard2 a mobilitydcatap:mobilityDataStandard ;
+    owl:versionInfo "DATEX II v3.2" ;
+    mobilitydcatap:schema <http://example.org/schemas/datex2> .
+
+# Explanation for Invalid Example 2:
+# This example is invalid because:
+# 1. The owl:versionInfo contains redundant acronyms and "v", which should be avoided.
+
+# Valid Example 3: Only schema property present
+# Explanation for Valid Example 3:
+# This example is valid because:
+# 1. It has the correct class.
+# 2. The mobilitydcatap:schema is a valid resource explicitly typed as rdfs:Resource.
+# 3. The version property is optional and can be omitted.
+:ValidStandard3 a mobilitydcatap:mobilityDataStandard ;
+    mobilitydcatap:schema :Schema2 .
+
+:Schema2 a rdfs:Resource .
+
+# Invalid Example 1: Multiple version properties
+:InvalidStandard1 a mobilitydcatap:mobilityDataStandard ;
+    owl:versionInfo "3.2" ;
+    owl:versionInfo "3.3" ;
+    mobilitydcatap:schema :Schema3 .
+
+:Schema3 a rdfs:Resource .
+
+# Invalid Example 2: Invalid version format
+# Validation Result for Invalid Example 2
+# Note: This is a semantic violation, not a syntactic one, so it might not be caught by all SHACL validators
+
+:InvalidStandard2 a mobilitydcatap:mobilityDataStandard ;
+    owl:versionInfo "DATEX II v3.2" ;
+    mobilitydcatap:schema :Schema4 .
+
+:Schema4 a rdfs:Resource .
+
+
+# Invalid Example 3: Schema is a literal instead of a resource
+#  "mobilitydcatap:schema  does not have class rdfs:Resource" ;
+:InvalidStandard3 a mobilitydcatap:mobilityDataStandard ;
+    owl:versionInfo "4.0" ;
+    mobilitydcatap:schema "http://example.org/schemas/datex2-v4.0" .
+
+
+

--- a/releases/1.0.1/validation/mobilitydcat-ap_shacl_shapes.ttl
+++ b/releases/1.0.1/validation/mobilitydcat-ap_shacl_shapes.ttl
@@ -1,0 +1,798 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+<http://w3id.org/mobilitydcat-ap#> a owl:Ontology , adms:Asset ;
+  owl:imports <https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1_shacl_shapes.ttl> ;
+  owl:imports <https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1_shacl_deprecateduris.ttl> ;
+  owl:imports <https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1_shacl_mdr-vocabularies.shape.ttl> ;
+  owl:imports <https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.0.0/mobilitydcat-ap.ttl> ;
+  owl:imports <http://www.w3.org/ns/dqv.ttl> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/SpatialDataServiceCategory.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/ConditionsApplyingToAccessAndUse.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/DegreeOfConformity.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/PriorityDataset/PriorityDataset.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/ProtocolValue/ProtocolValue.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/LimitationsOnPublicAccess.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/OnLineDescriptionCode.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/QualityOfServiceCriteria.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/ResourceType/ResourceType.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/ResponsiblePartyRole.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/SpatialDataServiceType.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/SpatialScope.en.rdf> ;
+  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/TopicCategory.en.rdf> ;
+  owl:versionIRI <http://w3id.org/mobilityDCAT-AP/releases/1.0.0/> ;
+  adms:status <http://publications.europa.eu/resource/dataset/dataset-status/COMPLETED> ;
+  dcatap:availability dcatap:stable ;
+  dct:conformsTo <https://www.w3.org/TR/shacl> ;
+  rdfs:isDefinedBy <https://w3id.org/mobilitydcat-ap/releases/1.0.0/> ;
+  dct:license <https://creativecommons.org/licenses/by/4.0> ;
+  dct:created "2023-08-14"^^xsd:date ;
+  dct:issued "2023-08-14"^^xsd:date ;
+  dct:modified "2023-10-19"^^xsd:date ;
+  dct:modified "2023-09-01"^^xsd:date ;
+  dct:dateCopyrighted "2023"^^xsd:gYear ;
+  dct:title "The constraints of mobilityDCAT-AP Application Profile for Data Portals in Europe"@en ;
+  owl:versionInfo "1.0.1" ;
+  dct:description "This document specifies the constraints on properties and classes expressed by mobilityDCAT-AP in SHACL."@en ;
+  bibo:editor [
+    a foaf:Person ;
+    owl:sameAs <https://lina-molinas-comet.name/foaf/#me>;
+    owl:sameAs <https://orcid.org/0000-0001-5446-6947> ;
+    foaf:name "Lina Molinas Comet"
+  ] ;
+  bibo:editor [
+    a foaf:Person ;
+    owl:sameAs <https://github.com/Daham-Mustaf>;
+    owl:sameAs <https://orcid.org/0000-0003-1867-4428> ;
+    foaf:name "Daham Mustafa"
+  ] ;
+  dct:creator [ a foaf:Group ;
+      foaf:name "NAPCORE SWG 4.4" ;
+      foaf:page <https://github.com/mobilityDCAT-AP/mobilityDCAT-AP> ] ;
+      dct:publisher <https://napcore.eu/> ;
+      dct:rightsHolder <https://napcore.eu/> ;
+      dcat:distribution [ a adms:AssetDistribution ;
+      dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE>,
+      <http://www.w3.org/ns/formats/data/Turtle> ;
+      dct:title "SHACL (Turtle)"@en ;
+      dcat:downloadURL <http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.shacl.ttl> ;
+      dcat:mediaType "text/turtle"^^dct:IMT
+  ] ;
+  .
+
+#-------------------------------------------------------------------------
+# The shapes in this file complement the DCAT-AP ones to cover all classes
+# in mobilityDCAT-AP 1.0.1.
+#-------------------------------------------------------------------------
+
+:Address_Agent_Shape
+  a sh:NodeShape ;
+  sh:name "Address (Agent)"@en ;
+  sh:targetClass locn:Address ;
+  sh:property [
+    # Recommended property for Address (Agent)
+    sh:maxCount 1 ;
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path locn:adminUnitL2 ;
+	  sh:name "administrative area" ;
+	  sh:description "The administrative area of an Address of the Agent. Depending on the country, this corresponds to a province, a county, a region, or a state." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Address (Agent)
+    sh:maxCount 1 ;
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path locn:postName ;
+    sh:name "city" ;
+    sh:description "The city of an Address of the Agent." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Address (Agent)
+    sh:maxCount 1 ;
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path locn:adminUnitL1 ;
+    sh:name "country" ;
+    sh:description "The country of an Address of the Agent." ;
+    sh:severity sh:Violation
+  ],
+   [
+    # Recommended property for Address (Agent)
+    sh:maxCount 1 ;
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path locn:postCode ;
+    sh:name "postal code" ;
+    sh:description "The postal code of an Address of the Agent." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Address (Agent)
+    sh:maxCount 1 ;
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path locn:thoroughfare ;
+    sh:name "street address" ;
+    sh:description "In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)" ;
+    sh:severity sh:Violation
+  ] .
+  
+:Agent_Shape
+  a sh:NodeShape ;
+    sh:targetClass foaf:Agent ;
+    sh:name "Agent"@en ;
+  sh:property[
+    # Optional property for Address (Agent)
+    sh:class locn:Address ;
+    # sh:nodeKind sh:Literal ;
+    sh:nodeKind sh:BlankNodeOrIRI;
+    sh:path locn:address ;
+    sh:name "address" ;
+    sh:description "This property MAY be used to specify the postal address of the Agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Address (Agent)
+    sh:class org:Organization ;
+    sh:path org:memberOf ;
+    sh:name "affiliation" ;
+    sh:description "If the agent is of type person, this property SHOULD be used to specify the affiliation of the Agent, see § 7. Agent Types, Agent Roles and Contact Information. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Address (Agent)
+    # sh:class owl:Thing ;
+    sh:path foaf:mbox ;
+    sh:nodeKind sh:IRI ;
+    # sh:pattern "^mailto:.+" ;
+    sh:name "email" ;
+    sh:description "This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Address (Agent)
+    sh:maxCount 1 ;
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    # sh:datatype xsd:string ;
+    sh:path foaf:firstName ;
+    sh:name "first name" ;
+    sh:description "If the agent is of type person, this property SHOULD be used to specify the first name of the Agent, see section § 7. Agent Types, Agent Roles and Contact Information." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Address (Agent)
+    # sh:class owl:Thing ;
+    sh:nodeKind sh:Literal ;
+    sh:path foaf:phone ;
+    sh:name "phone" ;
+    sh:description "This property MAY be used to provide the phone number of the Agent, specified using fully qualified tel: URI scheme [RFC3966]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Address (Agent)
+    sh:maxCount 1 ;
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    # sh:datatype xsd:string ;
+    sh:path foaf:surname ;
+    sh:name "surname" ;
+    sh:description "If the agent is of type person, this property SHOULD be used to specify the surname of the Agent, see section 7." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Address (Agent)
+    sh:maxCount 1 ;
+    sh:class rdfs:Resource ;
+    sh:path foaf:workplaceHomepage ;
+    sh:name "work place Homepage URL" ;
+    sh:description "If the agent is of type person, this property SHOULD be used to specify the surname of the Agent, see section 7." ;
+    sh:severity sh:Violation
+  ] .
+
+:Assessment_Shape
+  a sh:NodeShape ;
+  sh:targetClass mobilitydcatap:Assessment ;
+  sh:name "Assessment"@en ;
+  sh:property [
+    # Optional property for Assessment
+    sh:maxCount 1 ;
+    sh:path dct:issued ;
+            sh:or (
+        [
+          sh:datatype xsd:date ;
+        ]
+        [
+          sh:datatype xsd:dateTime ;
+        ]
+      );
+      sh:name "assessment date" ;
+      sh:description "This property MAY be used to describe the date of the latest assessment procedure. " ;
+      sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Assessment
+    sh:maxCount 1 ;
+    sh:class rdfs:Resource ;
+    sh:path oa:hasBody ;
+    sh:name "assessment result" ;
+    sh:description "This property MAY be used to describe the result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes." ;
+    sh:severity sh:Violation
+  ].
+
+:Catalogue_Shape
+  a sh:NodeShape ;
+  sh:targetClass dcat:Catalog ;
+  sh:name "Catalogue"@en ;
+  sh:property [
+    # Optional property for Catalogue
+    sh:maxCount 1 ;
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path dct:identifier ;
+    sh:name "identifier" ;
+    sh:description "This property MAY contain an identifier for the mobility data portal. Allows a unique identification of the individual portal and is used for referencing, e.g., when exchanging metadata between mobility data portals. This property SHOULD populated by the URI used within the RDF statement (via rdf:about). This property is analogue to an addition by [GEODCAT-AP-v2.0.0]." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Catalogue
+    sh:maxCount 1 ;
+    sh:class adms:Identifier ;
+    sh:path adms:identifier ;
+    sh:name "other identifier" ;
+    sh:description "This property MAY be used as an additional identifier, besides dct:identifier. It MAY be referring to a dedicated, EU-wide identificator system of NAPS or other portals, to be introduced in the future." ;
+    sh:severity sh:Violation
+  ] .
+
+:Catalog_Record_Shape
+  a sh:NodeShape ;
+  sh:targetClass dcat:CatalogRecord ;
+  sh:name "Catalogue Record"@en ;
+  sh:property [
+    # Mandatory property for Catalogue Record
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+	  sh:path dct:created ;
+            sh:or (
+			[
+				sh:datatype xsd:date ;
+			]
+			[
+				sh:datatype xsd:dateTime ;
+			]
+		);
+    sh:name "creation date" ;
+    sh:description "This property contains the date stamp (date and time) when the metadata entry was created for the first time. It SHOULD be generated by the system, whenever a platform user enters the metadata entry. " ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Catalogue Record
+    sh:maxCount 1 ;
+    sh:class foaf:Agent ;
+    sh:path dct:publisher ;
+    sh:name "publisher" ;
+    sh:description "This property refers to an entity (an organisation or a person), which is responsible for creation and maintenance of the metadata entry on the data platform. This entity is the direct contact for the data platform operators or data-searching users, who have questions or issues about the metadata entry. This information can be natively created by a data platform, then corresponding to the entity that is registered to the data platform and has the role of a metadata creator. This information can be also harvested from other portals. It should include, as a minimum, the name and email address of the entity. The information might be identical to the property “Publisher” of the corresponding dataset. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]." ;
+    sh:severity sh:Violation
+  ].
+
+:Category_Shape
+  a sh:NodeShape ;
+  sh:targetClass skos:Concept ;
+  sh:name "Category"@en ;
+  sh:property [
+    # Optional property for Category
+    sh:maxCount 1 ;
+    sh:class skos:ConceptScheme ;
+    sh:path skos:inScheme ;
+    sh:name "category scheme" ;
+    sh:description "This property MAY be used to specify the Category Scheme to which the Category belongs. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]." ;
+    sh:severity sh:Violation
+  ].
+
+:Dataset_Shape
+  a sh:NodeShape ;
+  sh:targetClass dcat:Dataset;
+  sh:name "Dataset"@en ;
+  sh:property [
+    # Mandatory property for Dataset
+    sh:minCount 1 ;
+	  sh:pattern "https://w3id.org/mobilitydcat-ap/mobility-theme" ;
+    sh:path mobilitydcatap:mobilityTheme ;
+    sh:name "mobility theme" ;
+    sh:description "This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content. A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content. The theme is described via a controlled vocabulary in two hierarchy levels: The 1st level is a mandatory field labelled ''Data content category'', describing the classification of the data content on an aggregated level. The 2nd level is an optional field labelled ''Data content sub category'', detailing the ''Data content category'' via one or several sub-categories. When entering the metadata for one dataset, the data provider would first select one or several options of a ''Data content category'', and then optionally details this with one or more options of corresponding “Data content sub category”. The platform must be able to handle the dependencies between these two levels, i.e., match the allowed options between the 1st and 2nd level. " ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Dataset
+    sh:pattern "https://w3id.org/mobilitydcat-ap/georeferencing-method" ;
+    sh:path mobilitydcatap:georeferencingMethod ;
+    sh:name "georeferencing method" ;
+    sh:description "This property SHOULD be used to specify the georeferencing method used in the dataset." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Dataset
+    sh:pattern "https://w3id.org/mobilitydcat-ap/network-coverage" ;
+    sh:path mobilitydcatap:networkCoverage ;
+    sh:name "network coverage" ;
+    sh:description "This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Dataset
+    sh:pattern "http://www.opengis.net/def/crs/EPSG/0/" ;
+    sh:path dct:conformsTo ;
+    sh:name "reference system" ;
+    sh:description "This property SHOULD be used to specify the spatial reference system used in the dataset. Spatial reference systems SHOULD be specified by using the corresponding URIs from the “EPSG coordinate reference systems” register operated by OGC." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Dataset
+    sh:class foaf:Agent ;
+    sh:path dct:rightsHolder ;
+    sh:name "rights holder" ;
+    sh:description "This property refers to an entity that legally owns or holds the rights of the data provided in a dataset. This entity is legally responsible for the content of the data. It is also responsible for any statements about the data quality (if applicable, see property dqv:hasQualityAnnotation) and/or the relevance to legal frameworks (if applicable, see property dcatap:applicableLegislation). This entity is the direct contact for the platform operator or data consumers, who have questions or issues about the contents of a dataset. The Rights Holder will be in many cases identical with the Publisher information for class Dataset (see property dct:publisher) and/or for class Catalogue Record (see property dct:publisher). In this case, the contact data MAY be copied from the corresponding Publisher entries. There might be also cases with non-identical entities: e.g., when one or several Rights Holders contract a third-party Publisher (e.g., an IT service company), which is producing, hosting and publishing a dataset." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Dataset
+    sh:pattern "https://w3id.org/mobilitydcat-ap/transport-mode" ;
+    sh:path mobilitydcatap:transportMode ;
+    sh:name "transport mode" ;
+    sh:description "This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied. " ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Dataset
+    sh:Class skos:Concept ;
+    sh:path dcatap:applicableLegislation ;
+    sh:name "applicable legislation" ;
+    sh:description "This property MAY refer to one or several legal frameworks being relevant for the dataset, e.g., an EC Delegated Regulation which constitutes the purpose of the corresponding data platform (here called National Access Point/NAP), or some other international or national frameworks, e.g., Open Data regulations. For European legal frameworks, it is recommended to use the European Legislation Identifier [ELI] to refer to legislation whenever possible. This property is derived from the DCAT-AP HVD extension " ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Dataset
+    sh:maxCount 1 ;
+    sh:Class mobilitydcatap:Assessment ;
+    sh:path mobilitydcatap:assessmentResult ;
+    sh:name "assessment result" ;
+    sh:description "This property MAY refer to the results and outcomes from an assessment process by some organisation, e.g., a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance of the Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies [NAPCORE-NB] and installed individually in each Member State. The property MAY point to the most recent assessment procedure, including its date, its result as a free-text and/or a link referring to an assessment report online. The difference to the property dqv:hasQualityAnnotation is that the latter one is provided by the data provider, while the assessment results are provided by an external organisation. " ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Dataset
+    sh:pattern "https://w3id.org/mobilitydcat-ap/intended-information-service" ;
+    sh:path mobilitydcatap:intentedInformationService;
+    sh:name "intended information service" ;
+    sh:description "This property MAY describe predefined information services, which the data content is intended to support. Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR]. Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Dataset
+    sh:Class dqv:QualityAnnotation ;
+    sh:path dqv:hasQualityAnnotation ;
+    sh:nodeKind sh:BlankNodeOrIRI ; # Add this to prevent literals
+    sh:name "quality description" ;
+    sh:description "This property MAY describe any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Rights Holder (see property dct:rightsHolder). This information SHOULD assist data consumers in determining the value of data, before actually accessing and processing it. Thus, the information SHOULD be publicly available. Furthermore, it can be helpful for validation processes by 3rd parties, e.g., a National Body in context of EU Delegated Regulations. Quality aspects SHOULD be noted via a free text and/or via URLs linking to further quality information. If there is absolutely no quality information, at least a note “quality information is unknown” SHOULD be given. If existing quality frameworks have been applied in the quality assessment, e.g., the Quality Packages from the EU EIP and NAPCORE projects [EU-EIP-QP], these frameworks should be referenced. " ;
+    sh:severity sh:Violation
+  ].
+ 
+ :Distribution_Shape
+  a sh:NodeShape ;
+   sh:targetClass dcat:Distribution ;
+  sh:name "Distribution"@en ;
+  sh:property [
+    # Mandatory property for Distribution
+    sh:pattern "https://w3id.org/mobilitydcat-ap/mobility-data-standard" ;
+    sh:Class mobilitydcatap:MobilityDataStandard  ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:path mobilitydcatap:mobilityDataStandard ;
+    sh:name "mobility data standard" ;
+    sh:description "This property describes the mobility data standard, as applied for the delivered content within the Distribution. A mobility data standard, e.g., DATEX II, combines syntax and semantic definitions of entities in a certain domain (e.g., for DATEX II: road traffic information), and optionally adds technical rules for data exchange. " ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Distribution
+    sh:pattern "https://w3id.org/mobilitydcat-ap/application-layer-protocol" ;
+    sh:path mobilitydcatap:applicationLayerProtocol ;
+    sh:maxCount 1 ;
+    sh:name "application layer protocol" ;
+    sh:description "This property describes the transmitting channel, i.e., the Application Layer Protocol, of the distribution." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Distribution
+    # sh:Class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path cnt:characterEncoding ;
+    sh:maxCount 1 ;
+    sh:name "character encoding" ;
+    sh:description "This property describes the technical encoding format of the delivered content within the Distribution. It is described via a character set standard. " ;
+    sh:severity sh:Violation
+  ] , 
+  [
+    # Optional property for Distribution
+    sh:pattern "https://w3id.org/mobilitydcat-ap/communication-method" ;
+    sh:path mobilitydcatap:communicationMethod ;
+    sh:maxCount 1 ;
+    sh:name "communication method" ;
+    sh:description "This property indicates for data services, e.g., data feeds, if the data interface of the data provider system functions in a push or pull mode." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Distribution
+    # sh:Class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path mobilitydcatap:dataFormatNotes ;
+    sh:maxCount 1 ;
+    sh:name "data format notes" ;
+    sh:description "This property contains any additional information about the format of the delivered content within the Distribution (see the corresponding properties dct:format, mobilitydcatap:mobilityDataStandard, mobilitydcatap:grammar), in a textual format. This might be about, e.g., extensions being used in a mobilitydcatap:mobilityDataStandard." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Distribution
+    sh:pattern "https://w3id.org/mobilitydcat-ap/grammar" ;
+    sh:path mobilitydcatap:grammar ;
+    sh:maxCount 1 ;
+    sh:name "grammar" ;
+    sh:description "This property describes the technical data grammar format of the delivered content within the Distribution. It describes the standard on top of the elementary syntax that describe data structures in the dataset. This is a sub-property of dct:conformsTo." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Distribution
+    sh:Class rdfs:Resource ;
+    sh:path adms:sample ;
+    sh:name "sample" ;
+    sh:description "This property refers to a sample Distribution of the Dataset. A data sample allows data users to investigate the data content and data structure, without subscribing to a data feed or downloading a complete data set. In [DCAT-AP-v2.0.1], there is a property adms:sample under the class dcat:Dataset , with a range of dcat:Distribution. This implies, that all mandatory properties from dcat:Distribution, e.g., mobilitydcatap:mobilityDataStandard, must be applied. To simplify the description of the Sample, mobilityDCAT-AP recommends to describe the Sample via a property under class dcat:Distribution. It is assumed that all other properties, as already populated for dcat:Distribution, e.g., mobilitydcatap:mobilityDataStandard, also apply for the description of the data sample. " ;
+    sh:severity sh:Violation
+  ] , 
+  [
+    # Optional property for Distribution
+    sh:Class dct:PeriodOfTime ;
+    sh:nodeKind sh:BlankNodeOrIRI ; # Add this to prevent literals
+	  sh:maxCount 1 ;
+    sh:path dct:temporal ;
+    sh:name "temporal coverage" ;
+    sh:description "This property describes the beginning and end of the time interval when a data service, e.g., a data feed, is delivered technically via the data platform. If there is no entry it means that the publication gets valid immediately and the timestamp is the same as the metadata timestamp." ;
+    sh:severity sh:Violation
+  ].
+
+:Kind_Shape
+  a sh:NodeShape ;
+  sh:targetClass  vcard:Kind ;
+  sh:name "Kind"@en ;
+  sh:property [
+    # Mandatory property for Kind
+    # sh:class owl:Thing ;
+    sh:path vcard:hasEmail ;
+    sh:name "email"@en ;
+    sh:description "This property contains an email address of the Kind, specified using fully qualified mailto: URI scheme [RFC6068]."@en ;
+    sh:minCount 1 ;
+    # sh:maxCount 1 ;  # Ensuring exactly one email address
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^mailto:.+" ;
+    sh:flags "i" ;  # Case-insensitive matching
+    sh:message "Email must be a valid mailto: URI"@en ;
+    sh:severity sh:Violation ;
+  ],  
+  [
+    # Mandatory property for Kind
+    # sh:Class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path vcard:fn ;
+    sh:minCount 1 ;
+    sh:name "name" ;
+    sh:description "This property contains a name of the Kind. This property can be repeated for different versions of the name (e.g., the name in different languages) - see § 8. Accessibility and Multilingual Aspects." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for Kind
+    # sh:class owl:Thing ;
+    sh:path vcard:hasURL ;
+    sh:maxCount 1 ;
+    sh:name "URL" ;
+    sh:description "This property points to a Web site of the Kind." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Kind
+    sh:class vcard:Address ;
+    sh:path vcard:hasAddress ;
+    sh:maxCount 1 ;
+    sh:name "address" ;
+    sh:description "This property MAY be used to specify the postal address of the Kind." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Kind
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path vcard:organization-name ;
+    sh:maxCount 1 ;
+    sh:name "affiliation" ;
+    sh:description "This property MAY be used to specify the affiliation of the Kind. This property can be repeated for different versions of the name (e.g. the name in different languages) - see § 8. Accessibility and Multilingual Aspects." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for Kind
+    # sh:class owl:Thing ;
+    sh:path vcard:hasTelephone ;
+    sh:name "phone" ;
+    sh:maxCount 1 ;
+    sh:description "This property MAY be used to provide the phone number of the Kind, specified using fully qualified tel: URI scheme [RFC3966]." ;
+    sh:severity sh:Violation
+  ] .
+
+:License_Document_Shape
+  a sh:NodeShape ;
+    sh:targetClass  dct:LicenseDocument ;
+  sh:name "License Document"@en ;
+  sh:property [
+    # Recommended property for License Document
+    sh:pattern "http://publications.europa.eu/resource/authority/access-right" ;
+    sh:path dct:identifier ;
+    sh:name "standard licence" ;
+    sh:maxCount 1 ;
+    sh:description "This property MAY be be used to link to a concrete standard license.  " ;
+    sh:severity sh:Violation
+  ],
+  [
+    # Optional property for License Document
+    # sh:Class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path rdfs:label ;
+    sh:name "licence text" ;
+    sh:maxCount 1 ;
+    sh:description "This property MAY be used to contain the full text of a Licence Document, as a free text. This MAY be used when there is no standard license that can be linked via property dct:identifier. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. " ;
+    sh:severity sh:Violation
+  ] .
+
+:Location_Shape
+  a sh:NodeShape ;
+  sh:targetClass  dct:Location ;
+  sh:name "Location"@en ;
+  sh:property [
+    # Recommended property for  Location
+    sh:class skos:ConceptScheme ;
+    sh:path skos:inScheme ;
+    sh:maxCount 1 ;
+    sh:name "gazetteer" ;
+    sh:description "This property MAY be used to specify the gazetteer to which the Location belongs. " ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for  Location
+    sh:path dct:identifier ;
+    sh:or (
+        [
+          sh:nodeKind sh:Literal ;
+        ]
+        [
+          sh:nodeKind sh:IRI  ;
+        ]
+      );
+    sh:name "geographic identifier" ;
+    sh:description "This property contains the geographic identifier for the Location, e.g., the URI or other unique identifier in the context of the relevant gazetteer." ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Optional property for  Location
+    # sh:class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path skos:prefLabel ;
+    sh:name "geographic name" ;
+    sh:description "This property contains a preferred label of the Location. This property can be repeated for parallel language versions of the label - see § 8. Accessibility and Multilingual Aspects." ;
+    sh:severity sh:Violation
+  ] .
+
+ :Mobility_Data_Standard_Shape
+  a sh:NodeShape ;
+  sh:targetClass mobilitydcatap:mobilityDataStandard ;
+  sh:name "Mobility Data Stadard"@en ;
+  sh:property [
+   # Optional property for  Mobility Data Stadard
+  #  sh:class rdfs:Literal  ;
+   sh:nodeKind sh:Literal ;
+   sh:path owl:versionInfo ;
+   sh:maxCount 1 ;
+   sh:name "version" ;
+   sh:description "This property describes the version of the mobility data standard, as applied within the delivered content. A version might be, e.g., DATEX II v3.2. This information is provided in a textual format. To avoid ambiguity, only short version identifiers SHOULD be used, e.g., only “3.2”, without redundant acronyms such as “v”, underscores etc." ;
+   sh:severity sh:Violation
+  ], 
+  [
+   # Optional property for  Mobility Data Stadard
+   sh:class rdfs:Resource  ;
+   sh:path mobilitydcatap:schema ;
+   sh:maxCount 1 ;
+   sh:name "schema" ;
+   sh:description "This property describes the schema of the mobility data standard, as applied within the delivered content. There are differet optiions how to reference the schema. It might be a reference to a portal-internal catalogue of schemas, a reference to an individual schema (that is provided by the data publisher), or a reference to an external catalogue of schemas (like a stakeholder-based DATEX II profile published on the datex2.eu page). The data platform SHOULD keep an archive of commonly used schemas. The data provider SHOULD be able to select an applicable schema from this archive, or to upload an own, individual schema. In any case, the schema should be available as a resource. This is a sub-property of dct:conformsTo." ;
+   sh:severity sh:Violation
+  ] .
+
+:Quality_Annotation_Shape
+  a sh:NodeShape ;
+    sh:targetClass dqv:QualityAnnotation ;
+  sh:name "Quality Annotation"@en ;
+  sh:property [
+   # Optional property for  Quality Annotation
+  #  sh:class rdfs:Literal  ;
+   sh:nodeKind sh:Literal ;
+   sh:path oa:hasBody ;
+   sh:maxCount 1 ;
+   sh:name "quality annotation resource" ;
+   sh:description "This property MAY be used to describe any quality aspects regarding the delivered content, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes." ;
+   sh:severity sh:Violation
+  ], 
+  [
+   # Optional property for  Quality Annotation
+   sh:class dcat:Dataset ;
+   sh:path oa:hasTarget ;
+   sh:maxCount 1 ;
+   sh:name "quality annotation target" ;
+   sh:description "This property MAY be used to describe the target of the quality annotation, referring back to the dataset being described. I.e., it is the inverse property of “dqv:hasQualityAnnotation”  for class Dataset." ;
+   sh:severity sh:Violation
+  ] .
+
+:Rights_Statement_Shape
+  a sh:NodeShape ;
+  sh:targetClass dct:RightsStatement ;
+  sh:name "Rights Statement"@en ;
+  sh:property [
+    # Mandatory property for  Rights Statement
+    sh:pattern "https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage" ;
+    sh:path dct:type ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:name "conditions for access and usage" ;
+    sh:description "This property SHOULD be used to indicate the conditions if any contracts, licences and/or are applied for the use of the dataset. The conditions are declared on an aggregated level: whether a free and unrestricted use is possible, a contract has to be concluded and/or a licence has to be agreed on to use a dataset. " ;
+    sh:severity sh:Violation
+  ], 
+  [
+    # Recommended property for  Rights Statement
+    # sh:Class rdfs:Literal ;
+    sh:nodeKind sh:Literal ;
+    sh:path rdfs:label ;
+    sh:name "Additional information for access and usage" ;
+    sh:description "This property MAY describes in a textual form any additional access, usage or licensing information, besides other information under classes dct:RightsStatement and dct:LicenseDocument. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects." ;
+    sh:severity sh:Violation
+  ] .
+#-------------------------------------------------------------------------
+# Concepts from controlled vocabularies defined and used in mobilityDCAT-AP.
+#-------------------------------------------------------------------------
+
+<https://w3id.org/mobilitydcat-ap/application-layer-protocol> a skos:ConceptScheme ;
+  skos:prefLabel "Application layer protocol"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/communication-method> a skos:ConceptScheme ;
+  skos:prefLabel "Communication method"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage> a skos:ConceptScheme ;
+  skos:prefLabel "Conditions for access and usage"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/mobility-theme> a skos:ConceptScheme ;
+  skos:prefLabel "Mobility Theme"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/mobility-data-standard> a skos:ConceptScheme ;
+  skos:prefLabel "Mobility Data Standard"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/georeferencing-method> a skos:ConceptScheme ;
+  skos:prefLabel "Georeferencing Method"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/grammar> a skos:ConceptScheme ;
+  skos:prefLabel "Grammar"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/network-coverage> a skos:ConceptScheme ;
+  skos:prefLabel "Network coverage"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/intended-information-service> a skos:ConceptScheme ;
+  skos:prefLabel "Intended Information Service"@en ;
+ . 
+
+<https://w3id.org/mobilitydcat-ap/transport-mode> a skos:ConceptScheme ;
+  skos:prefLabel "Transport mode"@en ;
+.
+
+<https://w3id.org/mobilitydcat-ap/update-frequency> a skos:ConceptScheme ;
+  skos:prefLabel "Update frequency"@en ;
+.
+
+
+#-------------------------------------------------------------------------
+# Concepts from additional controlled vocabularies used in mobilityDCAT-AP.
+#-------------------------------------------------------------------------
+
+<http://publications.europa.eu/resource/authority/data-theme> a skos:ConceptScheme ;
+  skos:prefLabel "Data Themes"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/data-theme> a skos:ConceptScheme ;
+  skos:prefLabel "Dataset Theme Vocabulary"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/access-right> a skos:ConceptScheme ;
+  skos:prefLabel "Access right"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/frequency> a skos:ConceptScheme ;
+  skos:prefLabel "Frequency"@en ;
+.
+
+<http://www.opengis.net/def/crs/EPSG/0/> a skos:ConceptScheme ;
+  skos:prefLabel "OGC EPSG Coordinate Reference Systems Register"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/file-type> a skos:ConceptScheme ;
+  skos:prefLabel "File Type"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/language> a skos:ConceptScheme ;
+  skos:prefLabel "Language"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/corporate-body> a skos:ConceptScheme ;
+  skos:prefLabel "Corporate body"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/continent> a skos:ConceptScheme ;
+  skos:prefLabel "Continents"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/country> a skos:ConceptScheme ;
+  skos:prefLabel "Countries"@en ;
+.
+
+<http://publications.europa.eu/resource/authority/place> a skos:ConceptScheme ;
+  skos:prefLabel "Places"@en ;
+.
+
+<http://sws.geonames.org/> a skos:ConceptScheme ;
+  skos:prefLabel "GeoNames"@en ;
+.
+
+<http://nuts.geovocab.org/> a skos:ConceptScheme;
+  skos:prefLabel "NUTS (Nomenclature of Territorial Units for Statistics)"@en ;
+.
+
+<http://purl.org/adms/publishertype/> a skos:ConceptScheme ;
+  skos:prefLabel "ADMS publisher type"@en ;
+.
+
+<https://eur-lex.europa.eu/eli-register/eu_publications_office.html> a skos:ConceptScheme ;
+  skos:prefLabel "European Legislation Identifier (ELI)"@en ;
+.
+
+
+
+
+

--- a/releases/1.0.1/validation/quality_annotation_shape.ttl
+++ b/releases/1.0.1/validation/quality_annotation_shape.ttl
@@ -1,0 +1,87 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Valid Quality Annotations
+
+# Valid Quality Annotation with Literal Body
+:TrafficFlowQuality a dqv:QualityAnnotation ;
+    oa:hasBody """Traffic flow data quality metrics:
+        - Data freshness: 3-minute update interval
+        - Spatial coverage: 98.5% of monitored road segments
+        - Accuracy: 95% validated against floating car data
+        - Completeness: 99.2% of expected measurements received"""@en ;
+    oa:hasTarget :FraunhoferTrafficDataset .
+
+:FraunhoferTrafficDataset a dcat:Dataset .
+
+# Valid Quality Annotation with Literal Body
+:PublicTransportQuality a dqv:QualityAnnotation ;
+    oa:hasBody """KVB Real-time Data Quality Report:
+        - Real-time arrival predictions available for 97% of stops
+        - Update frequency: 30 seconds
+        - Average prediction accuracy: ±2 minutes
+        - Service disruption reporting within 60 seconds
+        For detailed reports visit: https://opendata.cologne.de/dataset/kvb-realtime-quality"""@en ;
+    oa:hasTarget :CologneTransitDataset .
+
+:CologneTransitDataset a dcat:Dataset .
+
+# Invalid 
+:InvalidPublicTransportQuality a dqv:QualityAnnotation ;
+    oa:hasBody <https://opendata.cologne.de/dataset/kvb-realtime-quality> ; # *Invalid: Using IRI when literal is required*
+    oa:hasTarget :CologneTransitDataset .
+
+# Cologne Public Transport Real-time Quality
+:PublicTransportQuality a dqv:QualityAnnotation ;
+    oa:hasBody <https://opendata.cologne.de/dataset/kvb-realtime-quality> ;
+    oa:hasTarget :CologneTransitDataset .
+
+:CologneTransitDataset a dcat:Dataset .
+
+
+# Multiple Quality Report Links (Violates maxCount)
+:InvalidParkingQuality a dqv:QualityAnnotation ;
+    oa:hasBody <https://parking.data.de/quality/technical>, # *Invalid: Multiple hasBody values*
+               <https://parking.data.de/quality/business> ;
+    oa:hasTarget :ParkingDataset .
+
+:ParkingDataset a dcat:Dataset .
+
+# Multiple Target Datasets (Violates maxCount)
+:InvalidBikeShareQuality a dqv:QualityAnnotation ;
+    oa:hasBody "95% availability rate" ;
+    oa:hasTarget :BikeShareDataset1, # *Invalid: Multiple targets*
+                 :BikeShareDataset2 .
+
+:BikeShareDataset1 a dcat:Dataset .
+:BikeShareDataset2 a dcat:Dataset .
+
+
+# Invalid Target Type
+:InvalidTrafficSignalQuality a dqv:QualityAnnotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Signal timing accuracy: ±2 seconds"@en ;
+        dc:format "text/plain" ;
+        dc:language "en"
+    ] ;
+    oa:hasTarget "TrafficSignalSystem" . # *Invalid: Target should be a dcat:Dataset*

--- a/releases/1.0.1/validation/rights_statement_shape.ttl
+++ b/releases/1.0.1/validation/rights_statement_shape.ttl
@@ -1,0 +1,58 @@
+@prefix : <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Valid Rights Statements
+
+# Open Data Rights Statement for Cologne Traffic Data
+:CologneTrafficRights a dct:RightsStatement ;
+    dct:type <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/open-data-license> ;
+    rdfs:label "Free access under CC BY 4.0 with attribution to City of Cologne"@en,
+              "Freier Zugang unter CC BY 4.0 mit Namensnennung der Stadt Köln"@de .
+
+# Commercial License Rights Statement for Fraunhofer FIT's Mobility Analysis
+:FraunhoferMobilityRights a dct:RightsStatement ;
+    dct:type <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/commercial-license> ;
+    rdfs:label "Commercial license required. Contact mobility.data@fit.fraunhofer.de for access"@en,
+              "Kommerzielle Lizenz erforderlich. Kontaktieren Sie mobility.data@fit.fraunhofer.de für Zugang"@de .
+
+# Invalid Examples
+
+# Missing Type Property for Munich Transit Data
+:MunichTransitRights a dct:RightsStatement ;
+    rdfs:label "MVG open data terms of use apply"@en, # *Invalid: Missing mandatory dct:type*
+              "MVG Open Data Nutzungsbedingungen gelten"@de .
+
+# Wrong Pattern for Berlin Mobility Data
+:BerlinMobilityRights a dct:RightsStatement ;
+    dct:type <http://example.org/berlin-mobility-license> ; # *Invalid: Wrong pattern*
+    rdfs:label "Berlin Mobility Hub data access terms"@en .
+
+# Multiple Access Conditions (Violates maxCount)
+:HamburgPortRights a dct:RightsStatement ;
+    dct:type <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/research-use>, # *Invalid: Multiple types*
+             <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/commercial-use> ;
+    rdfs:label "Hamburg Port Authority mixed usage conditions"@en .
+
+# Non-Literal Label
+:DusseldorfTrafficRights a dct:RightsStatement ;
+    dct:type <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/open-data-license> ;
+    rdfs:label <http://example.org/terms> . # *Invalid: Label must be literal*


### PR DESCRIPTION
@marioscrock  @peterlubrich 

Added validation directory containing SHACL shape files for mobilityDCAT-AP 1.0.1

This PR adds a /validation folder with the following SHACL shape files for validating different components:
- address_agent_shape.ttl
- agent_shape.ttl
- assessment_shape.ttl
- catalogue_shape.ttl
- catalog_record_shape.ttl
- category_shape.ttl
- dataset_shape.ttl
- distribution_shape.ttl
- kind_shape.ttl
- license_document_shape.ttl
- location_shape.ttl
- mobility_data_standard_shape.ttl
- quality_annotation_shape.ttl
- rights_statement_shape.ttl

Also includes a README.md with validation documentation.
