### PR TITLE
Shacl validation improvements

### DIFF
--- a/releases/1.1.0/validationFiles/.docker/entrypoint.sh
+++ b/releases/1.1.0/validationFiles/.docker/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Usage
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <your_rdf_file.rdf>" >&2
+    exit 1
+fi
+
+MOBILITYDCAT_ENDPOINT="$1"
+
+wget -q "$MOBILITYDCAT_ENDPOINT" -O /app/nap_dataset
+
+cd /app/external_ontologies
+for file in * ; do
+    if [ -f "$file" ]; then
+        rapper -i guess "$file" -o ntriples >> /app/combined.nt
+    fi
+done
+
+cd /app
+rapper -i guess /app/nap_dataset -o ntriples >> /app/combined.nt
+
+pyshacl \
+    -d \
+    -s mobilitydcat-ap_shacl_shapes.ttl \
+    -f turtle \
+    -i none \
+    /app/combined.nt

--- a/releases/1.1.0/validationFiles/.docker/shacl-validation.Dockerfile
+++ b/releases/1.1.0/validationFiles/.docker/shacl-validation.Dockerfile
@@ -1,0 +1,51 @@
+# Use an official Python base image
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Install dependencies: wget, pyshacl
+RUN apt-get update && \
+    apt-get install -y wget raptor2-utils && \
+    pip install --no-cache-dir pyshacl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Download mobilityDCAT-AP ontology
+RUN wget https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/serialisationFiles/mobilitydcat-ap.ttl
+
+# Download external ontologies
+RUN mkdir external_ontologies
+WORKDIR /app/external_ontologies
+
+# List as per mobilitydcat https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#controlled-vocabularies-to-be-used
+RUN wget http://publications.europa.eu/resource/authority/data-theme -O data-theme.xml && \
+    wget http://publications.europa.eu/resource/authority/access-right -O access-right.rdf && \
+    wget http://publications.europa.eu/resource/authority/frequency -O frequency.rdf && \
+    wget http://publications.europa.eu/resource/authority/file-type -O file-type.rdf && \
+    wget http://publications.europa.eu/resource/authority/language -O language.rdf && \
+    wget http://publications.europa.eu/resource/authority/licence -O license.rdf && \
+    wget http://publications.europa.eu/resource/authority/corporate-body -O corporate-body.rdf && \
+    wget http://publications.europa.eu/resource/authority/continent -O continent.rdf && \
+    wget http://publications.europa.eu/resource/authority/country -O country.rdf && \
+    wget http://publications.europa.eu/resource/authority/place -O place.xml && \
+    wget http://publications.europa.eu/resource/authority/nuts -O nuts.xml && \
+    wget https://w3id.org/mobilitydcat-ap/application-layer-protocol && \
+    wget https://w3id.org/mobilitydcat-ap/communication-method && \
+    wget https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage && \
+    wget https://w3id.org/mobilitydcat-ap/mobility-theme && \
+    wget https://w3id.org/mobilitydcat-ap/mobility-data-standard && \
+    wget https://w3id.org/mobilitydcat-ap/georeferencing-method && \
+    wget https://w3id.org/mobilitydcat-ap/grammar && \
+    wget https://w3id.org/mobilitydcat-ap/network-coverage && \
+    wget https://w3id.org/mobilitydcat-ap/intended-information-service && \
+    wget https://w3id.org/mobilitydcat-ap/transport-mode && \
+    wget https://w3id.org/mobilitydcat-ap/update-frequency
+
+WORKDIR /app
+
+# Download shacl file
+COPY mobilitydcat-ap_shacl_shapes.ttl .
+
+COPY ./.docker/entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/releases/1.1.0/validationFiles/README.md
+++ b/releases/1.1.0/validationFiles/README.md
@@ -1,146 +1,19 @@
-# mobilityDCAT-AP Validation Files
+# mobilityDCAT-AP SHACL
 
-## Overview
+MobilityDCAT uses the [SHACL Shapes Constraint Language](https://www.w3.org/TR/shacl/) to encode the constraints to which datasets must adhere in order to be MobilityDCAT-compliant. 
+This folder contains the [SHACL shapes file](mobilitydcat-ap_shacl_shapes.ttl) as well as some `*_examples.ttl`-files that illustrate what both valid and invalid data look like.
 
-This repository contains validation files for the mobilityDCAT-AP specification. The [SHACL shapes file](mobilitydcat-ap_shacl_shapes.ttl) defines constraints for validating RDF data against the mobilityDCAT-AP requirements.
+## Running an automated validation (Docker)
 
-## ⚠️ SHACL Validation Requirements
+The `.docker` folder contains the necessary resources to build an image containing a basic validation setup using [pySHACL](https://github.com/RDFLib/pySHACL). 
 
-**Important**: The SHACL shapes require additional ontology models to be loaded for proper validation. Most SHACL validators do not perform automatic reasoning, which means class hierarchies (like `foaf:Organization` being a subclass of `foaf:Agent`) must be explicitly provided.
-
-### Required Ontologies
-
-Before validating your data, ensure you have these ontology files loaded:
-
-| Ontology | Purpose | Download Link |
-|----------|---------|---------------|
-| **FOAF** | Friend of a Friend vocabulary | [foaf.rdf](http://xmlns.com/foaf/spec/20140114.rdf) |
-| **Organization Ontology** | Organizational structures | [org.ttl](https://www.w3.org/ns/org.ttl) |
-| **DCAT** | Data Catalog Vocabulary | [dcat.ttl](https://www.w3.org/ns/dcat.ttl) |
-| **Dublin Core Terms** | Metadata elements | [dcterms.ttl](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.ttl) |
-| **SKOS** | Knowledge organization systems | [skos.ttl](https://www.w3.org/2009/08/skos-reference/skos.ttl) |
-| **vCard** | Contact information | [vcard.ttl](https://www.w3.org/2006/vcard/ns.ttl) |
-| **LOCN** | Location vocabulary | [locn.ttl](https://www.w3.org/ns/locn.ttl) |
-| **DQV** | Data Quality Vocabulary | [dqv.ttl](https://www.w3.org/ns/dqv.ttl) |
-| **DCAT-AP 2.0.1** | DCAT Application Profile | [dcat-ap.ttl](https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1.ttl) |
-| **mobilityDCAT-AP Core** | Main vocabulary | [mobilitydcat-ap.ttl](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/serialisationFiles/mobilitydcat-ap.ttl) |
-
-### Validation Commands
-
-**With pyshacl (supports reasoning):**
-
-First, install pyshacl:
+Building the validation image:
 ```bash
-# Install pyshacl
-pip install pyshacl
-
-# Or with conda
-conda install -c conda-forge pyshacl
+docker build -f ./.docker/shacl-validation.Dockerfile -t mobilitydcat-shacl-validator .
 ```
 
-Then download required ontologies and validate:
+Running a validation. This example validates the Belgian NAP catalog dataset.
 ```bash
-# Download required ontologies first
-wget https://www.w3.org/ns/dcat.ttl
-wget http://xmlns.com/foaf/spec/20140114.rdf
-wget https://www.w3.org/ns/org.ttl
-wget https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.ttl
-wget https://www.w3.org/2009/08/skos-reference/skos.ttl
-wget https://www.w3.org/2006/vcard/ns.ttl
-wget https://www.w3.org/ns/locn.ttl
-wget https://www.w3.org/ns/dqv.ttl
-wget https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1.ttl
-wget https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/serialisationFiles/mobilitydcat-ap.ttl
-
-# Validate with reasoning enabled
-pyshacl -s mobilitydcat-ap_shacl_shapes.ttl \
-        -e dcat.ttl \
-        -e foaf.rdf \
-        -e org.ttl \
-        -e dublin_core_terms.ttl \
-        -e skos.ttl \
-        -e vcard.ttl \
-        -e locn.ttl \
-        -e dqv.ttl \
-        -e dcat-ap_2.0.1.ttl \
-        -e mobilitydcat-ap.ttl \
-        -i rdfs \
-        your-data.ttl
+docker run mobilitydcat-shacl-validator "https://transportdata.be/catalog.ttl" > shacl_validation_report.ttl
 ```
 
-**With Apache Jena:**
-```bash
-# Merge all required graphs
-riot --validate your-data.ttl mobilitydcat-ap_shacl_shapes.ttl dcat.ttl foaf.rdf
-```
-
-### Validator Compatibility
-
-| Validator | Reasoning Support | Notes |
-|-----------|-------------------|-------|
-| **pyshacl** | ✅ With `-i rdfs` flag | Recommended approach |
-| **Apache Jena** | ❌ Manual ontology loading | Requires merging graphs |
-| **TopBraid** | ✅ Configurable | Commercial tool |
-| **SHACL Playground** | ❌ Manual setup | Include ontologies in data |
-
-> **💡 Tip**: Always specify which SHACL validator you used when reporting validation results, as different validators may behave differently.
-
-## Available Shapes and Examples
-
-Each class in the mobilityDCAT-AP specification has corresponding validation shapes and example files:
-
-### Core Components
-
-| Class | Documentation | Shape Definition | Example Files |
-|-------|--------------|------------------|--------------|
-| **Catalog** | [dcat:Catalog](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-catalogue) | [Catalogue_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [catalogue_shape](catalogue_shape_examples.ttl) |
-| **Catalog Record** | [dcat:CatalogRecord](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-catalogue-record) | [CatalogRecord_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [catalog_record_shape](catalog_record_shape_examples.ttl) |
-| **Dataset** | [dcat:Dataset](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-dataset) | [Dataset_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [dataset_shape](dataset_shape_examples.ttl) |
-| **Distribution** | [dcat:Distribution](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-distribution) | [Distribution_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [distribution_shape](distribution_shape_examples.ttl) |
-
-### Agents and Contact Information
-
-| Class | Documentation | Shape Definition | Example Files |
-|-------|--------------|------------------|--------------|
-| **Agent** | [foaf:Agent](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-agent) | [Agent_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [agent_shape](agent_shape_examples.ttl) |
-| **Address** | [locn:Address](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-address-agent) | [Address_Agent_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [address_agent](address_agent_examples.ttl) |
-| **Kind (Contact)** | [vcard:Kind](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-kind) | [Kind_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [kind_shape](kind_shape_examples.ttl) |
-
-### Metadata and Standards
-
-| Class | Documentation | Shape Definition | Example Files |
-|-------|--------------|------------------|--------------|
-| **Assessment** | [mobilitydcatap:Assessment](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-assessment) | [Assessment_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [assessment_shape](assessment_shape_examples.ttl) |
-| **Category** | [skos:Concept](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-category) | [Category_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [category_shape](category_shape_examples.ttl) |
-| **Location** | [dct:Location](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-location) | [Location_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [location_shape](location_shape_examples.ttl) |
-| **Mobility Data Standard** | [mobilitydcatap:MobilityDataStandard](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-mobility-data-standard) | [MobilityDataStandard_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [mobility_data_standard](mobility_data_standard_shape_examples.ttl) |
-
-### Rights and Quality Information
-
-| Class | Documentation | Shape Definition | Example Files |
-|-------|--------------|------------------|--------------|
-| **License Document** | [dct:LicenseDocument](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-licence-document) | [LicenseDocument_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [license_document_shape](license_document_shape_examples.ttl) |
-| **Quality Annotation** | [dqv:QualityAnnotation](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-quality-annotation) | [QualityAnnotation_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [quality_annotation_shape](quality_annotation_shape_examples.ttl) |
-| **Rights Statement** | [dct:RightsStatement](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/index.html#properties-for-rights-statement) | [RightsStatement_Shape](mobilitydcat-ap_shacl_shapes.ttl) | [rights_statement_shape](rights_statement_shape_examples.ttl) |
-
-## How to Use These Files
-
-1. **Documentation**: Click on the class name to view the full documentation for each class.
-2. **Shape Definition**: This is the SHACL shape that defines the validation rules for the class.
-3. **Example Files**: These contain examples of valid and invalid instances of each class.
-
-All shape definitions are contained in the main [SHACL shapes file](mobilitydcat-ap_shacl_shapes.ttl). The example files provide guidance on how to correctly implement each class in your data.
-
-## Common Validation Issues
-
-### Class Inheritance Problems
-If you see errors like `"foaf:Organization not recognized as foaf:Agent"`, ensure you have loaded the FOAF ontology that defines the class hierarchy.
-
-### Missing Controlled Vocabularies
-Some properties require values from controlled vocabularies. Ensure your data uses the correct URI patterns as defined in the SHACL shapes.
-
-## Future Improvements
-
-We are working with Peter to develop a comprehensive Docker-based validation tool with built-in reasoning support to eliminate the need for manual ontology management.
-
-For more information about the mobilityDCAT-AP specification, please visit the [official documentation](https://mobilitydcat-ap.github.io/mobilityDCAT-AP/).

--- a/releases/1.1.0/validationFiles/mobilitydcat-ap_shacl_shapes.ttl
+++ b/releases/1.1.0/validationFiles/mobilitydcat-ap_shacl_shapes.ttl
@@ -21,30 +21,15 @@
 @prefix spdx: <http://spdx.org/rdf/terms#> .
 
 
-<https://w3id.org/mobilitydcat-ap#> a owl:Ontology , adms:Asset ;
+<https://w3id.org/mobilitydcat-ap/releases/1.1.0/shacl> a owl:Ontology , adms:Asset ;
   owl:imports <https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1_shacl_shapes.ttl> ;
   owl:imports <https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1_shacl_deprecateduris.ttl> ;
   owl:imports <https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1_shacl_mdr-vocabularies.shape.ttl> ;
-  owl:imports <https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/serialisationFiles/mobilitydcat-ap.ttl> ;
-  owl:imports <http://www.w3.org/ns/dqv.ttl> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/SpatialDataServiceCategory.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse/ConditionsApplyingToAccessAndUse.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/DegreeOfConformity.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/PriorityDataset/PriorityDataset.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/ProtocolValue/ProtocolValue.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/LimitationsOnPublicAccess.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/OnLineDescriptionCode.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/QualityOfServiceCriteria/QualityOfServiceCriteria.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/ResourceType/ResourceType.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/ResponsiblePartyRole.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/SpatialDataServiceType.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/SpatialScope.en.rdf> ;
-  owl:imports <http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/TopicCategory.en.rdf> ;
-  owl:versionIRI <http://w3id.org/mobilityDCAT-AP/releases/1.1.0/> ;
+  owl:versionIRI <http://w3id.org/mobilityDCAT-AP/releases/1.1.0/shacl> ;
   adms:status <http://publications.europa.eu/resource/dataset/dataset-status/COMPLETED> ;
   dcatap:availability dcatap:stable ;
   dct:conformsTo <https://www.w3.org/TR/shacl> ;
-  rdfs:isDefinedBy <https://w3id.org/mobilitydcat-ap/releases/1.1.0/> ;
+  rdfs:isDefinedBy <https://w3id.org/mobilitydcat-ap/releases/1.1.0/shacl> ;
   dct:license <https://creativecommons.org/licenses/by/4.0> ;
   dct:created "2023-08-14"^^xsd:date ;
   dct:issued "2023-08-14"^^xsd:date ;
@@ -75,7 +60,7 @@
       dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE>,
       <http://www.w3.org/ns/formats/data/Turtle> ;
       dct:title "SHACL (Turtle)"@en ;
-      dcat:downloadURL <http://w3id.org/mobilitydcat-ap/releases/1.1.0/serialisationFiles/mobilitydcat-ap.shacl.ttl> ;
+      dcat:downloadURL <http://w3id.org/mobilitydcat-ap/releases/1.1.0/validationFiles/mobilitydcat-ap_shacl_shapes.ttl> ;
       dcat:mediaType "text/turtle"^^dct:IMT
   ] ;
   .


### PR DESCRIPTION
Dear maintainers,

During development on the Belgian NAP MobilityDCAT endpoint we encountered the need for more advanced SHACL validation. Upon closer inspection of the validation steps [proposed in the README](https://github.com/mobilityDCAT-AP/mobilityDCAT-AP/tree/gh-pages/releases/1.1.0/validationFiles/README.md) we concluded those to be untested/insufficient. Some examples are:
- Authoritative datasets referenced in the MobilityDCAT specification aren't included, which makes for false positives on [rules that check rdf types on entities from external namespaces](https://github.com/mobilityDCAT-AP/mobilityDCAT-AP/blob/f59298c676c218e9ea51b333b1db963f9087f443/releases/1.1.0/validationFiles/mobilitydcat-ap_shacl_shapes.ttl#L922) (as mentioned in https://github.com/mobilityDCAT-AP/mobilityDCAT-AP/issues/101 )
- The pySHACL [`-e`-option](https://github.com/RDFLib/pySHACL?tab=readme-ov-file#command-line-use) that can be used to include an additional ontology takes only 1 argument, which makes all the occurrences of `-e` except the last one useless. 
- The list of `wget` urls contains at least one reference to a file that probably never existed (`https://raw.githubusercontent.com/SEMICeu/DCAT-AP/master/releases/2.0.1/dcat-ap_2.0.1.ttl`). This file is only published as `.rdf`

This PR contains a Docker-based SHACL validation setup that replaces the instructions in the readme. This setup can serve as a working baseline that can be extended in the future.  It already loads the authoritative datasets referenced in the MobilityDCAT specification and appends those to the dataset under test. Inference is currently turned off, but can be enabled later on addition of the relevant ontologies such as `foaf`. In the same fashion as for the codelist-files, these will also have to be combined into one file and fed to the pySHACL `-e` option.
Feedback is very much welcomed!

Michaël Dierick
