### PR TITLE
fix(ontology): audit and correct mobilitydcat-ap_v1.1.0.ttl serialisation files

### DIFF
--- a/drafts/1.1.0-draft-0.1/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_minimum population_240205.ttl
+++ b/drafts/1.1.0-draft-0.1/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_minimum population_240205.ttl
@@ -1,61 +1,57 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix dc: <http://purl.org/dc/terms/> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <https://w3id.org/mobilitydcat-ap#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 <https://trafficdata.se/>
   a dcat:Catalog ;
-  dc:title "Trafficdata.se "@en ;
-  dc:description "The portal Trafficdata.se is a national service in which we gather information on, and provide you with access to, traffic and road network data. "@en ;
+  dct:title "Trafficdata.se"@en ;
+  dct:description "The portal Trafficdata.se is a national service in which we gather information on, and provide you with access to, traffic and road network data."@en ;
   foaf:homepage <https://trafficdata.se/> ;
-  dc:publisher <https://www.trafikverket.se/> ;
-  dc:spatial [
-    a dc:Location ;
-    dc:identifier <http://publications.europa.eu/resource/authority/country/SWE>
-  ] ;
+  dct:publisher <https://www.trafikverket.se/> ;
+  dct:spatial <http://publications.europa.eu/resource/authority/country/SWE> ;
   dcat:dataset <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa> ;
   dcat:record <https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits> .
 
 <https://www.trafikverket.se/>
   a foaf:Agent ;
-  foaf:name "Trafikverket" .
+  foaf:name "Trafikverket"@sv .
 
 <https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits>
   a dcat:CatalogRecord ;
   foaf:primaryTopic <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa> ;
-  dc:created "2019-12-04"^^xsd:date ;
-  dc:modified "2019-12-04"^^xsd:date ;
-  dc:language <http://publications.europa.eu/resource/authority/language/ENG> .
+  dct:created "2019-12-04"^^xsd:date ;
+  dct:modified "2019-12-04"^^xsd:date ;
+  dct:language <http://publications.europa.eu/resource/authority/language/ENG> .
 
 <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa>
   a dcat:Dataset ;
-  dc:title "Traffic signs expressing traffic regulations and identifying dangers, Speed limits" ;
-  dc:description "Traffic signs expressing traffic regulations and identifying dangers from the Swedish Transport Administration. Datex" ;
-  mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations>, <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits> ;
-  dc:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT> ;
-  dc:spatial [
-    a dc:Location ;
-    dc:identifier <http://publications.europa.eu/resource/authority/country/SWE>
-  ] ;
-  dc:publisher <https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b> ;
+  dct:title "Traffic signs expressing traffic regulations and identifying dangers, Speed limits"@en ;
+  dct:description "Traffic signs expressing traffic regulations and identifying dangers from the Swedish Transport Administration. Datex II format."@en ;
+  mobilitydcatap:mobilityTheme
+    <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations> ,
+    <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits> ;
+  dct:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT> ;
+  dct:spatial <http://publications.europa.eu/resource/authority/country/SWE> ;
+  dct:publisher <https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b> ;
   dcat:distribution <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa/resource/4d2cccaf-219f-4fe6-a22c-d695ce86699d> .
 
 <https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b>
-  a foaf:Organization ;
-  foaf:workplaceHomepage "www.trafikverket.se" ;
-  foaf:name "Trafikverket" ;
-  foaf:mbox "datex@trafikverket.se" .
+  a foaf:Agent ;
+  foaf:workplaceHomepage <https://www.trafikverket.se> ;
+  foaf:name "Trafikverket"@sv ;
+  foaf:mbox <mailto:datex@trafikverket.se> .
 
 <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa/resource/4d2cccaf-219f-4fe6-a22c-d695ce86699d>
   a dcat:Distribution ;
-  dcat:accessURL "http://www.trafikverket.se/tjanster/Oppna_data/trafikinformation-i-realtid/Trafikinformation-vag-i-realtid/Sa-har-far-du-tillgang-till-data-for-trafikinformation-i-realtid/" ;
-  dc:rights [
-    a dc:RightsStatement ;
-    dc:type <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided>
+  dcat:accessURL <http://www.trafikverket.se/tjanster/Oppna_data/trafikinformation-i-realtid/Trafikinformation-vag-i-realtid/Sa-har-far-du-tillgang-till-data-for-trafikinformation-i-realtid/> ;
+  dct:rights [
+    a dct:RightsStatement ;
+    dct:type <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided>
   ] ;
-  dc:format <http://publications.europa.eu/resource/authority/file-type/XML> ;
-  mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex-II> ;
+  dct:format <http://publications.europa.eu/resource/authority/file-type/XML> ;
+  mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex-II> .

--- a/drafts/1.1.0-draft-0.1/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_minimum population_240205.xml
+++ b/drafts/1.1.0-draft-0.1/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_minimum population_240205.xml
@@ -1,26 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<!-- This is a RDF example file for a NAP dateset according to the mobilityDCAT-AP v1.0 specification.
-It is fullfilling all mandatory and some recommended and optional elements from mobilityDCAT-AP.
-
-This example is based on a real-life NAP dataset from the Swedish NAP.
-The Swedish NAP already allows RDF/XML representations of its metadata records.
-The real-life NAP dataset can be assessed here:
-Human-readable HTML version:
-https://trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits
-Machine-readable RDF/XML version:
-https://trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits.xml
-
-Comments regarding the original RDF/XML representation are marked as follows:
-OK = this element can remain from the original
-PROPOSAL = this element can remain from the original; however, a proposal is given following the usage notes of mobilityDCAT-AP
-MODIFIED = changed element
-ADDED = new element
--->
-<!-- -->
 <rdf:RDF
   xmlns:foaf="http://xmlns.com/foaf/0.1/"
-  xmlns:ext="http://trafficdata.se/dcatext/"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:dcat="http://www.w3.org/ns/dcat#"
   xmlns:dct="http://purl.org/dc/terms/"
@@ -28,63 +8,61 @@ ADDED = new element
   xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap#"
   xmlns:dcatap="http://data.europa.eu/r5r/"
 >
+  <dcat:Catalog rdf:about="https://trafficdata.se/">
+    <dct:title xml:lang="en">Trafficdata.se</dct:title>
+    <dct:description xml:lang="en">The portal Trafficdata.se is a national service in which we gather information on, and provide you with access to, traffic and road network data.</dct:description>
+    <foaf:homepage rdf:resource="https://trafficdata.se/"/>
+    <dct:publisher>
+      <foaf:Agent rdf:about="https://www.trafikverket.se/">
+        <foaf:name xml:lang="sv">Trafikverket</foaf:name>
+      </foaf:Agent>
+    </dct:publisher>
+    <dct:spatial>
+      <dct:Location>
+        <dct:identifier rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/>
+      </dct:Location>
+    </dct:spatial>
+    <dcat:dataset rdf:resource="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa"/>
+    <dcat:record rdf:resource="https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits"/>
+  </dcat:Catalog>
 
-    <!-- The Class "Catalog" is mandatory. It describes the concrete NAP system. Thus, the block below is added with all mandatory properties for class Catalogue.-->
-    <dcat:Catalog rdf:about="https://trafficdata.se/">
-      <dct:title xml:lang="en">Trafficdata.se </dct:title> <!-- ADDED; mandatory property for class Catalogue -->
-      <dct:description xml:lang="en">The portal Trafficdata.se is a national service in which we gather information on, and provide you with access to, traffic and road network data. </dct:description> <!-- ADDED; mandatory property for class Catalogue -->
-      <foaf:homepage rdf:resource="https://trafficdata.se/"/> <!-- ADDED; mandatory property for class Catalogue -->
-      <dct:publisher> <!-- ADDED; mandatory property for class Catalogue -->
-        <foaf:Agent rdf:about="https://www.trafikverket.se/">
-          <foaf:name>Trafikverket</foaf:name>
-        </foaf:Agent>
-      </dct:publisher>
-      <dct:spatial> <!-- ADDED; mandatory property for class Catalogue -->
-        <dct:Location><!-- ADDED; class Location is the range of property spatial-->
-          <dct:identifier rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/><!-- ADDED; recommended property for class Location-->
-        </dct:Location>
-      </dct:spatial>
-    <dcat:dataset rdf:resource="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa"/> <!-- ADDED; mandatory property for class Catalogue -->
-    <dcat:record rdf:resource="https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits"/><!-- ADDED; mandatory property for class Catalogue -->
-    </dcat:Catalog>
+  <dcat:CatalogRecord rdf:about="https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits">
+    <foaf:primaryTopic rdf:resource="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa"/>
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-04</dct:created>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-04</dct:modified>
+    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG"/>
+  </dcat:CatalogRecord>
 
-    <!-- The Class "Catalogue Record" is mandatory. It describes the metadata entry in the NAP. Thus, the block below is added with all mandatory properties for "Catalogue Record". -->
-    <dcat:CatalogRecord rdf:about="https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits">
-  		<foaf:primaryTopic rdf:resource="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa"/> <!-- ADDED; mandatory property for class Catalogue Record-->
-  		<dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-04</dct:created> <!-- ADDED with arbitrary date; mandatory property for class Catalogue Record-->
-      <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-04</dct:modified> <!-- ADDED with arbitrary date; mandatory property for class Catalogue Record-->
-      <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG"/> <!-- ADDED; mandatory property for class Catalogue Record-->
-  	</dcat:CatalogRecord>
+  <dcat:Dataset rdf:about="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa">
+    <dct:title xml:lang="en">Traffic signs expressing traffic regulations and identifying dangers, Speed limits</dct:title>
+    <dct:description xml:lang="en">Traffic signs expressing traffic regulations and identifying dangers from the Swedish Transport Administration. Datex II format.</dct:description>
+    <mobilitydcatap:mobilityTheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <mobilitydcatap:mobilityTheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits"/>
+    <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT"/>
+    <dct:spatial>
+      <dct:Location>
+        <dct:identifier rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/>
+      </dct:Location>
+    </dct:spatial>
+    <dct:publisher>
+      <foaf:Agent rdf:about="https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b">
+        <foaf:workplaceHomepage rdf:resource="https://www.trafikverket.se"/>
+        <foaf:name xml:lang="sv">Trafikverket</foaf:name>
+        <foaf:mbox rdf:resource="mailto:datex@trafikverket.se"/>
+      </foaf:Agent>
+    </dct:publisher>
+    <dcat:distribution>
+      <dcat:Distribution rdf:about="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa/resource/4d2cccaf-219f-4fe6-a22c-d695ce86699d">
+        <dcat:accessURL rdf:resource="http://www.trafikverket.se/tjanster/Oppna_data/trafikinformation-i-realtid/Trafikinformation-vag-i-realtid/Sa-har-far-du-tillgang-till-data-for-trafikinformation-i-realtid/"/>
+        <dct:rights>
+          <dct:RightsStatement>
+            <dct:type rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided"/>
+          </dct:RightsStatement>
+        </dct:rights>
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/XML"/>
+        <mobilitydcatap:mobilityDataStandard rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex-II"/>
+      </dcat:Distribution>
+    </dcat:distribution>
+  </dcat:Dataset>
 
-    <dcat:Dataset rdf:about="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa">
-      <dct:title>Traffic signs expressing traffic regulations and identifying dangers, Speed limits</dct:title> <!-- OK; mandatory property for class Dataset-->
-      <dct:description>Traffic signs expressing traffic regulations and identifying dangers from the Swedish Transport Administration. Datex</dct:description> <!-- OK; mandatory property for class Dataset-->
-      <mobilitydcatap:mobilityTheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/><!-- MODIFIED from originally <dcat:theme rdf:resource="http://trafficdata.se/definitions/category/traffic_signs_expressing_traffic_regulations_and_identifying_dangers/speed_limits"/>; mandatory property for class Dataset -->
-      <mobilitydcatap:mobilityTheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits"/> <!-- MODIFIED from originally <dcat:theme rdf:resource="http://trafficdata.se/definitions/category/traffic_signs_expressing_traffic_regulations_and_identifying_dangers/speed_limits"/>; mandatory property for class Dataset -->
-      <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT"/><!--MODIFIED from originally rdf:resource="http://publications.europa.eu/mdr/authority/frequency/UPDATE_CONT"; mandatory property for class Dataset -->
-      <dct:spatial> <!--MODIFIED from originally <dct:spatial rdf:resource="http://sws.geonames.org/2661886"/>; mandatory property for class Dataset-->
-        <dct:Location><!-- OK; class Location is the range of property spatial-->
-          <dct:identifier rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/><!-- OK; recommended property for class Location-->
-        </dct:Location>
-      </dct:spatial>
-      <dct:publisher> <!-- OK; mandatory property for class Dataset-->
-        <foaf:Organization rdf:about="https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b"> <!-- OK; class Agent is the range of property publisher; Organization is a sub-class of class Agent-->
-          <foaf:workplaceHomepage>www.trafikverket.se</foaf:workplaceHomepage> <!-- MODIFIED from originally foaf:homepage; optional property for class Agent-->
-          <foaf:name>Trafikverket</foaf:name> <!-- OK; mandatory property for class Agent-->
-          <foaf:mbox>datex@trafikverket.se</foaf:mbox> <!-- OK; mandatory property for class Agent-->
-        </foaf:Organization>
-      </dct:publisher>
-      <dcat:distribution><!-- OK; mandatory property for class Dataset-->
-        <dcat:Distribution rdf:about="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa/resource/4d2cccaf-219f-4fe6-a22c-d695ce86699d"><!-- OK-->
-          <dcat:accessURL>http://www.trafikverket.se/tjanster/Oppna_data/trafikinformation-i-realtid/Trafikinformation-vag-i-realtid/Sa-har-far-du-tillgang-till-data-for-trafikinformation-i-realtid/</dcat:accessURL><!-- OK; mandatory property for class Distribution-->
-          <dct:rights><!-- ADDED; mandatory property for class Distribution-->
-            <dct:RightsStatement><!-- ADDED; class RightsStatement is the range of property rights-->
-              <dct:type rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided"/><!-- ADDED; mandatory property for class RightsStetement -->
-            </dct:RightsStatement>
-          </dct:rights>
-          <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/XML"/><!--MODIFIED from originally <dct:format>application/xml</dct:Format>; mandatory property for class Distribution-->
-          <mobilitydcatap:mobilityDataStandard rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex-II"/> <!-- ADDED; mandatory property for class Distribution-->
-        </dcat:Distribution>
-      </dcat:distribution>
-    </dcat:Dataset>
 </rdf:RDF>

--- a/drafts/1.1.0-draft-0.1/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.ttl
+++ b/drafts/1.1.0-draft-0.1/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.ttl
@@ -1,100 +1,76 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix dc: <http://purl.org/dc/terms/> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
+@prefix mobilitydcatap: <https://w3id.org/mobilitydcat-ap#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 <https://trafficdata.se/>
   a dcat:Catalog ;
-  dc:title "Trafficdata.se "@en ;
-  dc:description "The portal Trafficdata.se is a national service in which we gather information on, and provide you with access to, traffic and road network data. "@en ;
+  dct:title "Trafficdata.se"@en ;
+  dct:description "The portal Trafficdata.se is a national service in which we gather information on, and provide you with access to, traffic and road network data."@en ;
   foaf:homepage <https://trafficdata.se/> ;
-  dc:publisher <https://www.trafikverket.se/> ;
-  dc:spatial [
-    a dc:Location ;
-    dc:identifier <http://publications.europa.eu/resource/authority/country/SWE>
-  ] ;
+  dct:publisher <https://www.trafikverket.se/> ;
+  dct:spatial <http://publications.europa.eu/resource/authority/country/SWE> ;
   dcat:dataset <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa> ;
   dcat:record <https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits> .
 
 <https://www.trafikverket.se/>
   a foaf:Agent ;
-  foaf:name "Trafikverket" .
+  foaf:name "Trafikverket"@sv .
 
 <https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits>
   a dcat:CatalogRecord ;
   foaf:primaryTopic <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa> ;
-  dc:created "2019-12-04"^^xsd:date ;
-  dc:modified "2019-12-04"^^xsd:date ;
-  dc:language <http://publications.europa.eu/resource/authority/language/ENG> .
+  dct:created "2019-12-04"^^xsd:date ;
+  dct:modified "2019-12-04"^^xsd:date ;
+  dct:language <http://publications.europa.eu/resource/authority/language/ENG> .
 
 <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa>
   a dcat:Dataset ;
-  dc:title "Traffic signs expressing traffic regulations and identifying dangers, Speed limits" ;
-  dc:description "Traffic signs expressing traffic regulations and identifying dangers from the Swedish Transport Administration. Datex" ;
-  dc:identifier "ec459578-a11f-4728-acaa-16b08ae45cfa" ;
+  dct:title "Traffic signs expressing traffic regulations and identifying dangers, Speed limits"@en ;
+  dct:description "Traffic signs expressing traffic regulations and identifying dangers from the Swedish Transport Administration. Datex II format."@en ;
+  dct:identifier "ec459578-a11f-4728-acaa-16b08ae45cfa" ;
   dcat:theme <http://publications.europa.eu/resource/authority/data-theme/TRAN> ;
-  mobilitydcatap:mobilityTheme <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations>, <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits> ;
+  mobilitydcatap:mobilityTheme
+    <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations> ,
+    <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits> ;
   dcatap:applicableLegislation <http://data.europa.eu/eli/reg_del/2022/670/oj> ;
-  dcat:keyword "Datex", "Act B", "Speed limits" ;
-  dc:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT> ;
-  mobilitydcatap:networkCoverage <https://w3id.org/mobilitydcat-ap/network-coverage/motorways>, <https://w3id.org/mobilitydcat-ap/network-coverage/arterial-roads> ;
-  dc:spatial [
-    a dc:Location ;
-    dc:identifier <http://publications.europa.eu/resource/authority/country/SWE>
-  ] ;
-  dc:language <http://publications.europa.eu/resource/authority/language/ENG> ;
-  dc:issued "2017-05-09T11:49:47.718613"^^xsd:dateTime ;
-  dc:modified "2019-12-04T09:48:27.432387"^^xsd:dateTime ;
-  dc:publisher <https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b> ;
+  dcat:keyword "Datex"@en , "Act B"@en , "Speed limits"@en ;
+  dct:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT> ;
+  mobilitydcatap:networkCoverage
+    <https://w3id.org/mobilitydcat-ap/network-coverage/motorways> ,
+    <https://w3id.org/mobilitydcat-ap/network-coverage/arterial-roads> ;
+  dct:spatial <http://publications.europa.eu/resource/authority/country/SWE> ;
+  dct:language <http://publications.europa.eu/resource/authority/language/ENG> ;
+  dct:issued "2017-05-09T11:49:47.718613"^^xsd:dateTime ;
+  dct:modified "2019-12-04T09:48:27.432387"^^xsd:dateTime ;
+  dct:publisher <https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b> ;
   dcat:contactPoint [
     a vcard:Organization ;
-    vcard:hasEmail "datex@trafikverket" ;
+    vcard:hasEmail <mailto:datex@trafikverket.se> ;
     vcard:fn "Trafikverket"
   ] ;
-  dc:conformsTo <http://www.opengis.net/def/crs/EPSG/0/4326> ;
+  dct:conformsTo <http://www.opengis.net/def/crs/EPSG/0/4326> ;
   dcat:distribution <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa/resource/4d2cccaf-219f-4fe6-a22c-d695ce86699d> .
 
 <https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b>
-  a foaf:Organization ;
-  foaf:workplaceHomepage "www.trafikverket.se" ;
-  foaf:name "Trafikverket" ;
-  foaf:mbox "datex@trafikverket.se" .
+  a foaf:Agent ;
+  foaf:workplaceHomepage <https://www.trafikverket.se> ;
+  foaf:name "Trafikverket"@sv ;
+  foaf:mbox <mailto:datex@trafikverket.se> .
 
 <https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa/resource/4d2cccaf-219f-4fe6-a22c-d695ce86699d>
   a dcat:Distribution ;
-  dc:title "Datex" ;
-  dcat:accessURL "http://www.trafikverket.se/tjanster/Oppna_data/trafikinformation-i-realtid/Trafikinformation-vag-i-realtid/Sa-har-far-du-tillgang-till-data-for-trafikinformation-i-realtid/" ;
-  dc:rights [
-    a dc:RightsStatement ;
-    dc:type <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided>
+  dct:title "Datex II"@en ;
+  dcat:accessURL <http://www.trafikverket.se/tjanster/Oppna_data/trafikinformation-i-realtid/Trafikinformation-vag-i-realtid/Sa-har-far-du-tillgang-till-data-for-trafikinformation-i-realtid/> ;
+  dct:rights [
+    a dct:RightsStatement ;
+    dct:type <https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided>
   ] ;
-  dc:license <http://publications.europa.eu/resource/authority/licence/CC0> ;
-  dc:format <http://publications.europa.eu/resource/authority/file-type/XML> ;
+  dct:license <http://publications.europa.eu/resource/authority/licence/CC0> ;
+  dct:format <http://publications.europa.eu/resource/authority/file-type/XML> ;
   mobilitydcatap:mobilityDataStandard <https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex-II> ;
-  dc:description "Datex is the Swedish Transport Administration resource for Traffic signs expressing traffic regulations and identifying dangers" .
-
-# new specifications added to validate the file
-<https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided>
- a skos:Concept .
-
- <http://njh.me/>
- a dc:Standard .
-
- <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations>
- a skos:Concept .
-
- <https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits>
- a skos:Concept .
-
- <https://w3id.org/mobilitydcat-ap/network-coverage/motorways>
- a skos:Concept .
-
- <https://w3id.org/mobilitydcat-ap/network-coverage/arterial-roads>
- a skos:Concept .
-
- <https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex-II>
-  a skos:Concept .
+  dct:description "Datex II feed from the Swedish Transport Administration for traffic signs expressing traffic regulations and identifying dangers."@en .

--- a/drafts/1.1.0-draft-0.1/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.xml
+++ b/drafts/1.1.0-draft-0.1/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.xml
@@ -1,26 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<!-- This is a RDF example file for a NAP dateset according to the mobilityDCAT-AP v1.0 specification.
-It is fullfilling all mandatory and some recommended and optional elements from mobilityDCAT-AP.
-
+<!--
+This is a RDF example file for a NAP dataset according to the mobilityDCAT-AP v1.1.0 specification.
+It fulfils all mandatory and some recommended and optional elements from mobilityDCAT-AP.
 This example is based on a real-life NAP dataset from the Swedish NAP.
-The Swedish NAP already allows RDF/XML representations of its metadata records.
-The real-life NAP dataset can be assessed here:
+
 Human-readable HTML version:
 https://trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits
 Machine-readable RDF/XML version:
 https://trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits.xml
 
-Comments regarding the original RDF/XML representation are marked as follows:
+Comments:
 OK = this element can remain from the original
 PROPOSAL = this element can remain from the original; however, a proposal is given following the usage notes of mobilityDCAT-AP
 MODIFIED = changed element
 ADDED = new element
+FIXED = bug fixed in this version
 -->
-<!-- -->
 <rdf:RDF
   xmlns:foaf="http://xmlns.com/foaf/0.1/"
-  xmlns:ext="http://trafficdata.se/dcatext/"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:dcat="http://www.w3.org/ns/dcat#"
   xmlns:dct="http://purl.org/dc/terms/"
@@ -28,84 +25,133 @@ ADDED = new element
   xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap#"
   xmlns:dcatap="http://data.europa.eu/r5r/"
 >
+  <!-- The Class "Catalog" is mandatory. -->
+  <dcat:Catalog rdf:about="https://trafficdata.se/">
+    <dct:title xml:lang="en">Trafficdata.se</dct:title>
+    <!-- ADDED; mandatory property for class Catalogue -->
+    <dct:description xml:lang="en">The portal Trafficdata.se is a national service in which we gather information on, and provide you with access to, traffic and road network data.</dct:description>
+    <!-- ADDED; mandatory property for class Catalogue -->
+    <foaf:homepage rdf:resource="https://trafficdata.se/"/>
+    <!-- ADDED; mandatory property for class Catalogue -->
+    <dct:publisher>
+      <!-- ADDED; mandatory property for class Catalogue -->
+      <foaf:Agent rdf:about="https://www.trafikverket.se/">
+        <foaf:name xml:lang="sv">Trafikverket</foaf:name>
+      </foaf:Agent>
+    </dct:publisher>
+    <dct:spatial>
+      <!-- ADDED; mandatory property for class Catalogue -->
+      <dct:Location>
+        <!-- ADDED; class Location is the range of property spatial -->
+        <dct:identifier rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/>
+        <!-- ADDED; recommended property for class Location -->
+      </dct:Location>
+    </dct:spatial>
+    <dcat:dataset rdf:resource="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa"/>
+    <!-- ADDED; mandatory property for class Catalogue -->
+    <dcat:record rdf:resource="https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits"/>
+    <!-- ADDED; mandatory property for class Catalogue -->
+  </dcat:Catalog>
 
-    <!-- The Class "Catalog" is mandatory. It describes the concrete NAP system. Thus, the block below is added with all mandatory properties for class Catalogue.-->
-    <dcat:Catalog rdf:about="https://trafficdata.se/">
-      <dct:title xml:lang="en">Trafficdata.se </dct:title> <!-- ADDED; mandatory property for class Catalogue -->
-      <dct:description xml:lang="en">The portal Trafficdata.se is a national service in which we gather information on, and provide you with access to, traffic and road network data. </dct:description> <!-- ADDED; mandatory property for class Catalogue -->
-      <foaf:homepage rdf:resource="https://trafficdata.se/"/> <!-- ADDED; mandatory property for class Catalogue -->
-      <dct:publisher> <!-- ADDED; mandatory property for class Catalogue -->
-        <foaf:Agent rdf:about="https://www.trafikverket.se/">
-          <foaf:name>Trafikverket</foaf:name>
-        </foaf:Agent>
-      </dct:publisher>
-      <dct:spatial> <!-- ADDED; mandatory property for class Catalogue -->
-        <dct:Location><!-- ADDED; class Location is the range of property spatial-->
-          <dct:identifier rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/><!-- ADDED; recommended property for class Location-->
-        </dct:Location>
-      </dct:spatial>
-    <dcat:dataset rdf:resource="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa"/> <!-- ADDED; mandatory property for class Catalogue -->
-    <dcat:record rdf:resource="https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits"/><!-- ADDED; mandatory property for class Catalogue -->
-    </dcat:Catalog>
+  <!-- The Class "Catalogue Record" is mandatory. -->
+  <dcat:CatalogRecord rdf:about="https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits">
+    <foaf:primaryTopic rdf:resource="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa"/>
+    <!-- ADDED; mandatory property for class Catalogue Record -->
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-04</dct:created>
+    <!-- ADDED; mandatory property for class Catalogue Record -->
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-04</dct:modified>
+    <!-- ADDED; mandatory property for class Catalogue Record -->
+    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG"/>
+    <!-- ADDED; mandatory property for class Catalogue Record -->
+  </dcat:CatalogRecord>
 
-    <!-- The Class "Catalogue Record" is mandatory. It describes the metadata entry in the NAP. Thus, the block below is added with all mandatory properties for "Catalogue Record". -->
-    <dcat:CatalogRecord rdf:about="https://www.trafficdata.se/dataset/traffic-signs-expressing-traffic-regulations-and-identifying-dangers-speed-limits">
-  		<foaf:primaryTopic rdf:resource="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa"/> <!-- ADDED; mandatory property for class Catalogue Record-->
-  		<dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-04</dct:created> <!-- ADDED with arbitrary date; mandatory property for class Catalogue Record-->
-      <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-12-04</dct:modified> <!-- ADDED with arbitrary date; mandatory property for class Catalogue Record-->
-      <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG"/> <!-- ADDED; mandatory property for class Catalogue Record-->
-  	</dcat:CatalogRecord>
+  <dcat:Dataset rdf:about="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa">
+    <dct:title xml:lang="en">Traffic signs expressing traffic regulations and identifying dangers, Speed limits</dct:title>
+    <!-- FIXED: language tag added; mandatory property for class Dataset -->
+    <dct:description xml:lang="en">Traffic signs expressing traffic regulations and identifying dangers from the Swedish Transport Administration. Datex II format.</dct:description>
+    <!-- FIXED: language tag added; mandatory property for class Dataset -->
+    <dct:identifier>ec459578-a11f-4728-acaa-16b08ae45cfa</dct:identifier>
+    <!-- PROPOSAL: dct:identifier should be populated by the URI used within rdf:about; optional property for class Dataset -->
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/TRAN"/>
+    <!-- OK; recommended property for class Dataset -->
+    <mobilitydcatap:mobilityTheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/>
+    <!-- MODIFIED; mandatory property for class Dataset -->
+    <mobilitydcatap:mobilityTheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits"/>
+    <!-- MODIFIED; mandatory property for class Dataset -->
+    <dcatap:applicableLegislation rdf:resource="http://data.europa.eu/eli/reg_del/2022/670/oj"/>
+    <!-- ADDED; optional property for class Dataset -->
+    <dcat:keyword xml:lang="en">Datex</dcat:keyword>
+    <!-- PROPOSAL: redundant with mobilityDataStandard value; optional property for class Dataset -->
+    <dcat:keyword xml:lang="en">Act B</dcat:keyword>
+    <!-- PROPOSAL: redundant with applicableLegislation value; optional property for class Dataset -->
+    <dcat:keyword xml:lang="en">Speed limits</dcat:keyword>
+    <!-- PROPOSAL: redundant with second mobilityTheme value; optional property for class Dataset -->
+    <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT"/>
+    <!-- MODIFIED; mandatory property for class Dataset -->
+    <mobilitydcatap:networkCoverage rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/motorways"/>
+    <!-- MODIFIED; recommended property for class Dataset -->
+    <mobilitydcatap:networkCoverage rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/arterial-roads"/>
+    <!-- MODIFIED; recommended property for class Dataset -->
+    <dct:spatial>
+      <!-- MODIFIED; mandatory property for class Dataset -->
+      <dct:Location>
+        <dct:identifier rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/>
+        <!-- OK; recommended property for class Location -->
+      </dct:Location>
+    </dct:spatial>
+    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG"/>
+    <!-- OK; optional property for class Dataset -->
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-05-09T11:49:47.718613</dct:issued>
+    <!-- OK; optional property for class Dataset -->
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-12-04T09:48:27.432387</dct:modified>
+    <!-- OK; optional property for class Dataset -->
+    <dct:publisher>
+      <!-- OK; mandatory property for class Dataset -->
+      <foaf:Agent rdf:about="https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b">
+        <!-- FIXED: foaf:Organization -> foaf:Agent -->
+        <foaf:workplaceHomepage rdf:resource="https://www.trafikverket.se"/>
+        <!-- FIXED: string -> IRI; optional property for class Agent -->
+        <foaf:name xml:lang="sv">Trafikverket</foaf:name>
+        <!-- OK; mandatory property for class Agent -->
+        <foaf:mbox rdf:resource="mailto:datex@trafikverket.se"/>
+        <!-- FIXED: string -> mailto: IRI; mandatory property for class Agent -->
+      </foaf:Agent>
+    </dct:publisher>
+    <dcat:contactPoint>
+      <!-- OK; recommended property for class Dataset -->
+      <vcard:Organization>
+        <vcard:hasEmail rdf:resource="mailto:datex@trafikverket.se"/>
+        <!-- FIXED: string -> mailto: IRI; mandatory property for class Kind -->
+        <vcard:fn>Trafikverket</vcard:fn>
+        <!-- OK; mandatory property for class Kind -->
+      </vcard:Organization>
+    </dcat:contactPoint>
+    <dct:conformsTo rdf:resource="http://www.opengis.net/def/crs/EPSG/0/4326"/>
+    <!-- MODIFIED; recommended property for class Dataset — reference system -->
+    <dcat:distribution>
+      <!-- OK; mandatory property for class Dataset -->
+      <dcat:Distribution rdf:about="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa/resource/4d2cccaf-219f-4fe6-a22c-d695ce86699d">
+        <dct:title xml:lang="en">Datex II</dct:title>
+        <!-- FIXED: language tag added; optional property for class Distribution -->
+        <dcat:accessURL rdf:resource="http://www.trafikverket.se/tjanster/Oppna_data/trafikinformation-i-realtid/Trafikinformation-vag-i-realtid/Sa-har-far-du-tillgang-till-data-for-trafikinformation-i-realtid/"/>
+        <!-- FIXED: string -> IRI; mandatory property for class Distribution -->
+        <dct:rights>
+          <!-- ADDED; mandatory property for class Distribution -->
+          <dct:RightsStatement>
+            <dct:type rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided"/>
+            <!-- ADDED; mandatory property for class RightsStatement -->
+          </dct:RightsStatement>
+        </dct:rights>
+        <dct:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC0"/>
+        <!-- MODIFIED; recommended property for class Distribution -->
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/XML"/>
+        <!-- MODIFIED; mandatory property for class Distribution -->
+        <mobilitydcatap:mobilityDataStandard rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex-II"/>
+        <!-- ADDED; mandatory property for class Distribution -->
+        <dct:description xml:lang="en">Datex II feed from the Swedish Transport Administration for traffic signs expressing traffic regulations and identifying dangers.</dct:description>
+        <!-- FIXED: language tag added; optional property for class Distribution -->
+      </dcat:Distribution>
+    </dcat:distribution>
+  </dcat:Dataset>
 
-    <dcat:Dataset rdf:about="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa">
-      <dct:title>Traffic signs expressing traffic regulations and identifying dangers, Speed limits</dct:title> <!-- OK; mandatory property for class Dataset-->
-      <dct:description>Traffic signs expressing traffic regulations and identifying dangers from the Swedish Transport Administration. Datex</dct:description> <!-- OK; mandatory property for class Dataset-->
-      <dct:identifier>ec459578-a11f-4728-acaa-16b08ae45cfa</dct:identifier> <!-- PROPOSAL: according to SEMIC advice, dct:identifier should be populated by the URI used within the RDF statement (via rdf:about), but additional identifiers should be noted via adms:identifier; optional property for class Dataset; -->
-      <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/TRAN"/> <!-- OK; recommended property for class Dataset-->
-      <mobilitydcatap:mobilityTheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-traffic-signs-and-regulations"/><!-- MODIFIED from originally <dcat:theme rdf:resource="http://trafficdata.se/definitions/category/traffic_signs_expressing_traffic_regulations_and_identifying_dangers/speed_limits"/>; mandatory property for class Dataset -->
-      <mobilitydcatap:mobilityTheme rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/dynamic-speed-limits"/> <!-- MODIFIED from originally <dcat:theme rdf:resource="http://trafficdata.se/definitions/category/traffic_signs_expressing_traffic_regulations_and_identifying_dangers/speed_limits"/>; mandatory property for class Dataset -->
-      <dcatap:applicableLegislation rdf:resource="http://data.europa.eu/eli/reg_del/2022/670/oj"/> <!-- ADDED; optional property for class Dataset -->
-      <dcat:keyword>Datex</dcat:keyword><!-- PROPOSAL: this keyword is redundant, as it is already noted by the value of mobilitydcatap:mobilityDataStandard, see below; recommended property for class Dataset -->
-      <dcat:keyword>Act B</dcat:keyword> <!-- PROPOSAL: this keyword is redundant, as it is already noted by the value of dcatap:applicableLegislation, see above; recommended property for class Dataset -->
-      <dcat:keyword>Speed limits</dcat:keyword> <!-- PROPOSAL: this keyword is redundant, as it is already noted by the second value of mobilitydcatap:mobilityTheme, see above; recommended property for class Dataset -->
-      <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT"/><!--MODIFIED from originally rdf:resource="http://publications.europa.eu/mdr/authority/frequency/UPDATE_CONT"; mandatory property for class Dataset -->
-      <mobilitydcatap:networkCoverage rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/motorways"/> <!--MODIFIED from originally <ext:networkcoverage rdf:resource="http://trafficdata.se/definitions/networkcoverage/motorways"/>; recommended property for class Dataset  -->
-      <mobilitydcatap:networkCoverage rdf:resource="https://w3id.org/mobilitydcat-ap/network-coverage/arterial-roads"/> <!--MODIFIED from originally <ext:networkcoverage rdf:resource="http://trafficdata.se/definitions/networkcoverage/arterial_roads"/>; recommended property for class Dataset  -->
-      <dct:spatial> <!--MODIFIED from originally <dct:spatial rdf:resource="http://sws.geonames.org/2661886"/>; mandatory property for class Dataset-->
-        <dct:Location><!-- OK; class Location is the range of property spatial-->
-          <dct:identifier rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/><!-- OK; recommended property for class Location-->
-        </dct:Location>
-      </dct:spatial>
-      <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG"/> <!-- OK; optional property for class Dataset- -->
-      <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-05-09T11:49:47.718613</dct:issued> <!-- OK; optional property for class Dataset-->
-      <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-12-04T09:48:27.432387</dct:modified> <!-- OK; optional property for class Dataset-->
-      <dct:publisher> <!-- OK; mandatory property for class Dataset-->
-        <foaf:Organization rdf:about="https://www.trafficdata.se/organization/0a3a8800-a545-4538-a2ab-e7a11246ff9b"> <!-- OK; class Agent is the range of property publisher; Organization is a sub-class of class Agent-->
-          <foaf:workplaceHomepage>www.trafikverket.se</foaf:workplaceHomepage> <!-- MODIFIED from originally foaf:homepage; optional property for class Agent-->
-          <foaf:name>Trafikverket</foaf:name> <!-- OK; mandatory property for class Agent-->
-          <foaf:mbox>datex@trafikverket.se</foaf:mbox> <!-- OK; mandatory property for class Agent-->
-        </foaf:Organization>
-      </dct:publisher>
-      <dcat:contactPoint> <!-- OK; recommended property for class Dataset-->
-        <vcard:Organization rdf:nodeID="N81652eb8d2ea499d817fdab36534e1d6"> <!-- OK; class Kind is the range of property contactPoint; Organization is a sub-class of class Kind-->
-          <vcard:hasEmail>datex@trafikverket</vcard:hasEmail><!-- OK; mandatory property for class Kind-->
-          <vcard:fn>Trafikverket</vcard:fn><!-- OK; mandatory property for class Kind-->
-        </vcard:Organization>
-      </dcat:contactPoint>
-      <dct:conformsTo rdf:resource="http://www.opengis.net/def/crs/EPSG/0/4326"/><!-- MODIFIED: there has been no value for this property in the original file; in mobilityDCAT-AP, this property is used for describing a spatial reference system; an arbitrary value from the EPSG code list is entered for this example.-->
-      <dcat:distribution><!-- OK; mandatory property for class Dataset-->
-        <dcat:Distribution rdf:about="https://www.trafficdata.se/dataset/ec459578-a11f-4728-acaa-16b08ae45cfa/resource/4d2cccaf-219f-4fe6-a22c-d695ce86699d"><!-- OK-->
-          <dct:title>Datex</dct:title><!-- OK; optional property for class Distribution-->
-          <dcat:accessURL>http://www.trafikverket.se/tjanster/Oppna_data/trafikinformation-i-realtid/Trafikinformation-vag-i-realtid/Sa-har-far-du-tillgang-till-data-for-trafikinformation-i-realtid/</dcat:accessURL><!-- OK; mandatory property for class Distribution-->
-          <dct:rights><!-- ADDED; mandatory property for class Distribution-->
-            <dct:RightsStatement><!-- ADDED; class RightsStatement is the range of property rights-->
-              <dct:type rdf:resource="https://w3id.org/mobilitydcat-ap/conditions-for-access-and-usage/licence-provided"/><!-- ADDED; mandatory property for class RightsStetement -->
-            </dct:RightsStatement>
-          </dct:rights>
-          <dct:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC0"/> <!-- MODIFIED from originally <dct:license rdf:resource="http://www.opendefinition.org/licenses/cc-zero"/>; recommended property for class Distribution-->>
-          <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/XML"/><!--MODIFIED from originally <dct:format>application/xml</dct:Format>; mandatory property for class Distribution-->
-          <mobilitydcatap:mobilityDataStandard rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-data-standard/datex-II"/> <!-- ADDED; mandatory property for class Distribution-->
-          <dct:description>Datex is the Swedish Transport Administration resource for Traffic signs expressing traffic regulations and identifying dangers</dct:description><!-- OK; recommended property for class Distribution-->
-        </dcat:Distribution>
-      </dcat:distribution>
-    </dcat:Dataset>
 </rdf:RDF>

--- a/drafts/1.1.0-draft-0.1/mobilitydcat-ap_v1.1.0.jsonld
+++ b/drafts/1.1.0-draft-0.1/mobilitydcat-ap_v1.1.0.jsonld
@@ -492,7 +492,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       }
     },
     {
@@ -514,7 +514,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       }
     },
     {
@@ -539,7 +539,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       }
     },
     {
@@ -561,7 +561,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       }
     },
     {
@@ -583,7 +583,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -611,7 +611,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -639,7 +639,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -667,7 +667,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -695,7 +695,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -723,7 +723,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "mobilitydcatap:Assessment"
@@ -751,7 +751,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Catalog"
@@ -780,7 +780,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:CatalogRecord"
@@ -809,7 +809,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:CatalogRecord"
@@ -838,7 +838,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "skos:Concept"
@@ -870,7 +870,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -902,7 +902,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -931,7 +931,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -960,7 +960,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -992,7 +992,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -1024,7 +1024,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -1056,7 +1056,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -1088,7 +1088,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -1120,7 +1120,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -1152,7 +1152,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Dataset"
@@ -1187,7 +1187,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Distribution"
@@ -1219,7 +1219,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Distribution"
@@ -1251,7 +1251,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Distribution"
@@ -1286,7 +1286,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Distribution"
@@ -1315,7 +1315,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Distribution"
@@ -1344,7 +1344,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Distribution"
@@ -1373,7 +1373,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "vcard:Kind"
@@ -1402,7 +1402,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "vcard:Kind"
@@ -1431,7 +1431,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "vcard:Kind"
@@ -1460,7 +1460,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "vcard:Kind"
@@ -1489,7 +1489,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dct:LicenseDocument"
@@ -1518,7 +1518,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dct:Location"
@@ -1553,7 +1553,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "mobilitydcatap:MobilityDataStandard"
@@ -1581,7 +1581,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dqv:QualityAnnotation"
@@ -1610,7 +1610,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dct:RightsStatement"
@@ -1637,7 +1637,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -1664,7 +1664,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -1691,7 +1691,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -1718,7 +1718,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -1745,7 +1745,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -1772,7 +1772,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "mobilitydcatap:Assessment"
@@ -1799,7 +1799,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -1826,7 +1826,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "locn:Address"
@@ -1853,7 +1853,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Catalog"
@@ -1880,7 +1880,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:CatalogRecord"
@@ -1911,7 +1911,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Distribution"
@@ -1939,7 +1939,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dcat:Distribution"
@@ -1967,7 +1967,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "vcard:Kind"
@@ -1995,7 +1995,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "vcard:Kind"
@@ -2023,7 +2023,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dct:LicenseDocument"
@@ -2051,7 +2051,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dct:Location"
@@ -2079,7 +2079,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dct:Location"
@@ -2106,7 +2106,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "mobilitydcatap:MobilityDataStandard"
@@ -2133,7 +2133,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "mobilitydcatap:MobilityDataStandard"
@@ -2160,7 +2160,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dqv:QualityAnnotation"
@@ -2188,7 +2188,7 @@
         "@language": "en"
       },
       "adms:status": {
-        "@id": "http://publications.europa.eu/resource/dataset/concept-status/CURRENT"
+        "@id": "http://publications.europa.eu/resource/authority/concept-status/CURRENT"
       },
       "dcam:domainIncludes": {
         "@id": "dct:RightsStatement"

--- a/drafts/1.1.0-draft-0.1/mobilitydcat-ap_v1.1.0.rdf
+++ b/drafts/1.1.0-draft-0.1/mobilitydcat-ap_v1.1.0.rdf
@@ -421,7 +421,7 @@
         <rdfs:label xml:lang="en">applicable legislation</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -468,7 +468,7 @@
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
         <skos:scopeNote xml:lang="en">This property refers to a temporal period, i.e., the beginning and the end, of the time reference of the delivered content (e.g., validity time of a public-transport time table).</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -489,7 +489,7 @@
         <rdfs:label xml:lang="en">application layer protocol</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this property is recommended to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -504,7 +504,7 @@
         <rdfs:label xml:lang="en">assessment result</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -519,7 +519,7 @@
         <rdfs:label xml:lang="en">communication method</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -534,7 +534,7 @@
         <rdfs:label xml:lang="en">georeferencing method</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -550,7 +550,7 @@
         <rdfs:label xml:lang="en">grammar</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -565,7 +565,7 @@
         <rdfs:label xml:lang="en">intended information service</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -581,7 +581,7 @@
         <rdfs:label xml:lang="en">mobility data standard</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -596,7 +596,7 @@
         <rdfs:label xml:lang="en">mobility theme</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for  Dataset.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -611,7 +611,7 @@
         <rdfs:label xml:lang="en">network coverage</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -627,7 +627,7 @@
         <rdfs:label xml:lang="en">schema</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -642,7 +642,7 @@
         <rdfs:label xml:lang="en">transportation mode</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -660,7 +660,7 @@
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for  Location.</skos:scopeNote>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for  Category.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -674,7 +674,7 @@
         <rdfs:label xml:lang="en">address</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -688,7 +688,7 @@
         <rdfs:label xml:lang="en">email</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -702,7 +702,7 @@
         <rdfs:label xml:lang="en">phone</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -716,7 +716,7 @@
         <rdfs:label xml:lang="en">URL</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -729,7 +729,7 @@
         <rdfs:comment xml:lang="en">This property MAY be used as an additional identifier, besides dct:identifier. It MAY be referring to a dedicated, EU-wide identificator system of NAPS or other portals, to be introduced in the future.</rdfs:comment>
         <rdfs:label xml:lang="en">other identifier</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Catalogue. </skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -743,7 +743,7 @@
         <rdfs:label xml:lang="en">sample</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -766,7 +766,7 @@
         <rdfs:label xml:lang="en">quality description</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -779,7 +779,7 @@
         <rdfs:comment xml:lang="en">This property MAY be used to specify the postal address of the Agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
         <rdfs:label xml:lang="en">address</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -798,7 +798,7 @@
         <rdfs:comment xml:lang="en">This property MAY be used to describe the target of the quality annotation, referring back to the dataset being described. I.e., it is the inverse property of “dqv:hasQualityAnnotation” for class Dataset.</rdfs:comment>
         <rdfs:label xml:lang="en">quality annotation target</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Quality Annotation. </skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -811,7 +811,7 @@
         <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the affiliation of the Agent, see § 7. Agent Types, Agent Roles and Contact Information. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
         <rdfs:label xml:lang="en">affiliation</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -824,7 +824,7 @@
         <rdfs:comment xml:lang="en">This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
         <rdfs:label xml:lang="en">email</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -837,7 +837,7 @@
         <rdfs:comment xml:lang="en">This property MAY be used to provide the phone number of the Agent, specified using fully qualified tel: URI scheme [RFC3966]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
         <rdfs:label xml:lang="en">phone</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -850,7 +850,7 @@
         <rdfs:comment xml:lang="en">This property MAY be used to specify the Web site of the Agent.</rdfs:comment>
         <rdfs:label xml:lang="en">URL</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:ObjectProperty>
 
 
@@ -894,7 +894,7 @@
         <rdfs:label xml:lang="en">data format notes</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -921,7 +921,7 @@
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Location.</skos:scopeNote>
         <skos:scopeNote xml:lang="en">This property contains a preferred label of the Category. This property can be repeated for parallel language versions of the label - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -935,7 +935,7 @@
         <rdfs:label xml:lang="en">name</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -949,7 +949,7 @@
         <rdfs:label xml:lang="en">affiliation</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -963,7 +963,7 @@
         <rdfs:label xml:lang="en">character encoding</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -976,7 +976,7 @@
         <rdfs:comment xml:lang="en">The country of an Address of the Agent.</rdfs:comment>
         <rdfs:label xml:lang="en">country</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -989,7 +989,7 @@
         <rdfs:comment xml:lang="en">The administrative area of an Address of the Agent. Depending on the country, this corresponds to a province, a county, a region, or a state.</rdfs:comment>
         <rdfs:label xml:lang="en">administrative area</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -1002,7 +1002,7 @@
         <rdfs:comment xml:lang="en">The postal code of an Address of the Agent.</rdfs:comment>
         <rdfs:label xml:lang="en">postal code</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -1015,7 +1015,7 @@
         <rdfs:comment xml:lang="en">The city of an Address of the Agent.</rdfs:comment>
         <rdfs:label xml:lang="en">city</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -1028,7 +1028,7 @@
         <rdfs:comment xml:lang="en">The street name and civic number of an Address of the Agent.</rdfs:comment>
         <rdfs:label xml:lang="en">street address</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -1047,7 +1047,7 @@
         <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the first name of the Agent, see section § 7. Agent Types, Agent Roles and Contact Information.</rdfs:comment>
         <rdfs:label xml:lang="en">first name</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -1060,7 +1060,7 @@
         <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the surname of the Agent, see section 7.</rdfs:comment>
         <rdfs:label xml:lang="en">surname</rdfs:label>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:DatatypeProperty>
 
 
@@ -1098,7 +1098,7 @@
         <rdfs:label xml:lang="en">Assessment</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:Class>
 
 
@@ -1112,7 +1112,7 @@
         <rdfs:label xml:lang="en">Mobility Data Standard</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory class.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:Class>
 
 
@@ -1136,7 +1136,7 @@
         <rdfs:label xml:lang="en">Quality Annotation</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:Class>
 
 
@@ -1148,7 +1148,7 @@
         <rdfs:label xml:lang="en">Address (Agent)</rdfs:label>
         <vs:term_status>stable</vs:term_status>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </owl:Class>
 
 
@@ -1404,7 +1404,7 @@
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Dataset. </skos:scopeNote>
         <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
         <dcam:rangeIncludes rdf:resource="http://purl.org/dc/terms/Standard"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.org/dc/terms/created">
         <rdfs:comment xml:lang="en">This property contains the date stamp (date and time) when the metadata entry was created for the first time. It SHOULD be generated by the system, whenever a platform user enters the metadata entry. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
@@ -1412,7 +1412,7 @@
         <rdfs:label xml:lang="en">creation date</rdfs:label>
         <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Catalogue Record. Its range is rdfs:Literal typed as xsd:date or xsd:dateTime. </skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.org/dc/terms/hasPart">
         <skos:scopeNote xml:lang="en">This property refers to a related Catalogue that is part of the described mobility data portal. This property could be used to link the mobility data portal to another data portal, by e.g. harvesting metadata from this other portal into the mobility data portal. </skos:scopeNote>
@@ -1422,7 +1422,7 @@
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.org/dc/terms/identifier">
         <vs:term_status>stable</vs:term_status>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
         <rdfs:comment xml:lang="en">This property MAY contain an identifier for the mobility data portal. Allows a unique identification of the individual portal and is used for referencing, e.g., when exchanging metadata between mobility data portals. This property SHOULD populated by the URI used within the RDF statement (via rdf:about). This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
         <rdfs:comment xml:lang="en">This property MAY be be used to link to a concrete standard license. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.  </rdfs:comment>
         <rdfs:label xml:lang="en">standard licence</rdfs:label>
@@ -1454,14 +1454,14 @@
         <skos:scopeNote xml:lang="en">This property contains the date of formal issuance (e.g., publication) of the Catalogue.</skos:scopeNote>
         <rdfs:comment xml:lang="en">This property MAY be used to describe the date of the latest assessment procedure.</rdfs:comment>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Assessment. Its range is rdfs:Literal typed as xsd:date or xsd:dateTime. </skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.org/dc/terms/language">
         <skos:scopeNote xml:lang="en">This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the metadata entry. The value should be generated automatically by the NAP system, corresponding to the currently used language in the user interface. Some portals offer multilingual user interfaces, e.g., in the local language and additionally in English. For multiple languages - see § 8. Accessibility and Multilingual Aspects. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.</skos:scopeNote>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.org/dc/terms/publisher">
         <dcam:rangeIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
         <rdfs:comment xml:lang="en">This property refers to an entity (an organisation or a person), which is responsible for creation and maintenance of the metadata entry on the data platform. This entity is the direct contact for the data platform operators or data-searching users, who have questions or issues about the metadata entry. This information can be natively created by a data platform, then corresponding to the entity that is registered to the data platform and has the role of a metadata creator. This information can be also harvested from other portals. It should include, as a minimum, the name and email address of the entity. The information might be identical to the property “Publisher” of the corresponding dataset. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
         <rdfs:label xml:lang="en">publisher</rdfs:label>
         <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
@@ -1470,7 +1470,7 @@
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.org/dc/terms/source">
         <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
         <rdfs:comment xml:lang="en">This property is used for metadata records that are harvested from other portals. Harvesting, i.e., the automated import of metadata information from external portals, seems to be a common case for some NAPs. With these property, a data user can see, if the metadata was harvested, and from where. The property SHOULD link to a public URL of the dataset descripton on the original data portal, from where the metadata was harvested.</rdfs:comment>
         <rdfs:label xml:lang="en">source metadata</rdfs:label>
         <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
@@ -1485,7 +1485,7 @@
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.org/dc/terms/rightsHolder">
         <rdfs:comment xml:lang="en">This property refers to an entity that legally owns or holds the rights of the data provided in a dataset. This entity is legally responsible for the content of the data. It is also responsible for any statements about the data quality (if applicable, see property dqv:hasQualityAnnotation) and/or the relevance to legal frameworks (if applicable, see property dcatap:applicableLegislation). This entity is the direct contact for the platform operator or data consumers, who have questions or issues about the contents of a dataset. The Rights Holder will be in many cases identical with the Publisher information for class Dataset (see property dct:publisher) and/or for class Catalogue Record (see property dct:publisher). In this case, the contact data MAY be copied from the corresponding Publisher entries. There might be also cases with non-identical entities: e.g., when one or several Rights Holders contract a third-party Publisher (e.g., an IT service company), which is producing, hosting and publishing a dataset. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Dataset. </skos:scopeNote>
         <vs:term_status>stable</vs:term_status>
         <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
@@ -1503,7 +1503,7 @@
         <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
         <rdfs:comment xml:lang="en">This property SHOULD be used to indicate the conditions if any contracts, licences and/or are applied for the use of the dataset. The conditions are declared on an aggregated level: whether a free and unrestricted use is possible, a contract has to be concluded and/or a licence has to be agreed on to use a dataset. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. The values can be logically mapped with the property dct:identifier from class dct:LicenseDocument. </rdfs:comment>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Rights Statement.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://spdx.org/rdf/terms#Checksum">
         <skos:scopeNote xml:lang="en">A value that allows the contents of a file to be authenticated. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented. In [DCAT-AP-v2.0.1], this class is defined as the range for the optional property &apos;&apos;spdx:checksum&apos;&apos; of class Distribution. However, in mobilityDCAT-AP, this property is removed. So, the class and its properties are without function but kept for compatibility reasons.</skos:scopeNote>
@@ -1524,7 +1524,7 @@
         <rdfs:label xml:lang="en">Additional information for access and usage</rdfs:label>
         <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/LicenseDocument"/>
         <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/RightsStatement"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
         <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.org/dc/terms/conformsTo">
@@ -1532,7 +1532,7 @@
         <rdfs:comment xml:lang="en">This property describes the name of the mobility data standard. This property is necessary for the following CASE 1: A custom instance of mobilitydcatap:MobilityDataStandard is defined. Such custom instance is recommended when the mobility data standard is detailed out via properties owl:versionInfo and/or mobilitydcatap:schema. The property dct:conformsTo would then name the mobility data standard via a controlled vocabulary. In the alternative CASE 2, the name the mobility data standard is directly named as range of mobilitydcatap:MobilityDataStandard, again via the same controlled vocabulary.</rdfs:comment>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard. </skos:scopeNote>
         <dcam:domainIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
         <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#versionInfo">
@@ -1541,7 +1541,7 @@
         <skos:scopeNote xml:lang="en">This property contains a version number or other version designation of the dataset. The version should be updated, whenever there are changes to the dataset noted by the property dct:modified. Together with property adms:versionNotes, this MAY also enable a change history (or version history) of the corresponding dataset, which could be hosted and published on the data platform. It is recommended to follow W3C Data on the Web Best Practices [DWBP]. Version identifiers should enable comparison of versions and distinguishing major from minor versions, such as Semantic Versioning [SEMVER].</skos:scopeNote>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard. </skos:scopeNote>
         <dcam:domainIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
         <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     </rdf:Description>
     <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#Concept">
@@ -1636,7 +1636,7 @@
         <dcam:domainIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#Assessment"/>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Assessment. </skos:scopeNote>
         <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dqv#QualityAnnotation"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>
+        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
         <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Quality Annotation. </skos:scopeNote>
         <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
         <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>

--- a/drafts/1.1.0-draft-0.1/mobilitydcat-ap_v1.1.0.rdf
+++ b/drafts/1.1.0-draft-0.1/mobilitydcat-ap_v1.1.0.rdf
@@ -1,1660 +1,962 @@
-<?xml version="1.0"?>
-<rdf:RDF xmlns="http://w3id.org/mobilitydcat-ap#"
-     xml:base="http://w3id.org/mobilitydcat-ap"
-     xmlns:oa="http://www.w3.org/ns/oa#"
-     xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
-     xmlns:cnt="http://www.w3.org/2011/content#"
-     xmlns:dct="http://purl.org/dc/terms/"
-     xmlns:dqv="http://www.w3.org/ns/dqv#"
-     xmlns:org="http://www.w3.org/ns/org#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:xml="http://www.w3.org/XML/1998/namespace"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:adms="http://www.w3.org/ns/adms#"
-     xmlns:bibo="http://purl.org/ontology/bibo/"
-     xmlns:dcam="http://purl.org/dc/dcam/"
-     xmlns:dcat="http://www.w3.org/ns/dcat#"
-     xmlns:foaf="http://xmlns.com/foaf/0.1/"
-     xmlns:locn="http://www.w3.org/ns/locn#"
-     xmlns:prov="http://www.w3.org/ns/prov#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-     xmlns:spdx="http://spdx.org/rdf/terms#"
-     xmlns:vann="http://purl.org/vocab/vann/"
-     xmlns:voaf="http://purl.org/vocommons/voaf#"
-     xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
-     xmlns:dcatap="http://data.europa.eu/r5r/"
-     xmlns:mobilitydcatap="http://w3id.org/mobilitydcat-ap#">
-    <owl:Ontology rdf:about="http://w3id.org/mobilitydcat-ap#">
-        <owl:versionIRI rdf:resource="http://w3id.org/mobilityDCAT-AP/releases/1.0.0/"/>
-        <dct:abstract xml:lang="en">mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. </dct:abstract>
-        <dct:alternative xml:lang="en">mobilityDCAT-AP - Version 1.0.0: A mobility extension for the DCAT application profile for data portals in Europe</dct:alternative>
-        <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-05-11</dct:created>
-        <dct:creator>
-            <rdf:Description>
-                <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Group"/>
-                <foaf:name>NAPCORE SWG 4.4</foaf:name>
-                <foaf:page rdf:resource="https://github.com/mobilityDCAT-AP/mobilityDCAT-AP"/>
-            </rdf:Description>
-        </dct:creator>
-        <dct:dateCopyrighted rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">2023</dct:dateCopyrighted>
-        <dct:description xml:lang="en">mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. </dct:description>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-05-11</dct:issued>
-        <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-        <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-07-24</dct:modified>
-        <dct:title xml:lang="en">mobilityDCAT-AP</dct:title>
-        <bibo:editor rdf:resource="https://lina-molinas-comet.name/foaf/#me"/>
-        <bibo:editor>
-            <rdf:Description>
-                <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
-                <foaf:name>Lina Molinas Comet</foaf:name>
-            </rdf:Description>
-        </bibo:editor>
-        <vann:preferredNamespacePrefix>mobilitydcatap</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://w3id.org/mobilitydcat-ap/</vann:preferredNamespaceUri>
-        <voaf:reliesOn rdf:resource="http://data.europa.eu/r5r/"/>
-        <voaf:reliesOn rdf:resource="http://purl.org/dc/terms/"/>
-        <voaf:reliesOn rdf:resource="http://spdx.org/rdf/terms#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/2002/07/owl#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/2004/02/skos/core#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/2006/vcard/ns#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/2011/content#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/ns/adms#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/ns/dcat#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/ns/dqv#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/ns/locn#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/ns/org#"/>
-        <voaf:reliesOn rdf:resource="http://www.w3.org/ns/prov#"/>
-        <voaf:reliesOn rdf:resource="http://xmlns.com/foaf/0.1/"/>
-        <rdfs:comment xml:lang="en">mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. </rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilityDCAT-AP/releases/1.0.0/"/>
-        <rdfs:label xml:lang="en">mobilityDCAT-AP</rdfs:label>
-        <owl:backwardCompatibleWith rdf:resource="http://w3id.org/mobilityDCAT-AP/releases/1.0.0/"/>
-        <owl:priorVersion rdf:resource="http://w3id.org/mobilityDCAT-AP/releases/1.0.0/"/>
-        <owl:versionInfo xml:lang="en">Version 1.0.0</owl:versionInfo>
-        <skos:altLabel xml:lang="en">mobilityDCAT-AP - Version 1.0.0: A mobility extension for the DCAT application profile for data portals in Europe</skos:altLabel>
-        <adms:last rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <adms:prev rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/dataset-status/COMPLETED"/>
-        <adms:versionNotes xml:lang="en">This version of mobilityDCAT-AP extends [DCAT-AP-v2.0.1] with 2 additional classes and 48 additional properties (some of which re-used across classes).</adms:versionNotes>
-        <dcat:distribution>
-            <rdf:Description rdf:nodeID="genid3">
-                <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
-                <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/JSON_LD"/>
-                <dct:format rdf:resource="http://www.w3.org/ns/formats/data/JSON-LD"/>
-                <dct:title xml:lang="en">JSON-LD</dct:title>
-                <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
-                <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
-                <dcat:downloadURL rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.jsonld"/>
-                <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/application/ld+json"/>
-            </rdf:Description>
-        </dcat:distribution>
-        <dcat:distribution>
-            <rdf:Description rdf:nodeID="genid4">
-                <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
-                <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE"/>
-                <dct:format rdf:resource="http://www.w3.org/ns/formats/data/Turtle"/>
-                <dct:title xml:lang="en">Turtle</dct:title>
-                <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
-                <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
-                <dcat:downloadURL rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.ttl"/>
-                <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
-            </rdf:Description>
-        </dcat:distribution>
-        <dcat:distribution>
-            <rdf:Description rdf:nodeID="genid5">
-                <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
-                <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/RDF_XML"/>
-                <dct:format rdf:resource="http://www.w3.org/ns/formats/data/RDF_XML"/>
-                <dct:title xml:lang="en">RDF/XML</dct:title>
-                <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
-                <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
-                <dcat:downloadURL rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.rdf"/>
-                <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
-            </rdf:Description>
-        </dcat:distribution>
-        <dcat:distribution>
-            <rdf:Description rdf:nodeID="genid6">
-                <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
-                <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/HTML"/>
-                <dct:title xml:lang="en">HTML</dct:title>
-                <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/HumanLanguage"/>
-                <dcat:downloadURL rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/"/>
-                <dcat:mediaType rdf:datatype="http://purl.org/dc/terms/IMT">text/html</dcat:mediaType>
-            </rdf:Description>
-        </dcat:distribution>
-        <foaf:depiction rdf:resource="https://mobilitydcat-ap.github.io/mobilityDCAT-AP/drafts/latest/mobilityDCAT-AP_uml-diagramm_230719.png"/>
-    </owl:Ontology>
-
-
-
-    <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotation properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-
-
-    <!-- http://purl.org/dc/dcam/domainIncludes -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/dcam/domainIncludes"/>
-
-
-
-    <!-- http://purl.org/dc/dcam/rangeIncludes -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/dcam/rangeIncludes"/>
-
-
-
-    <!-- http://purl.org/dc/terms/abstract -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/abstract"/>
-
-
-
-    <!-- http://purl.org/dc/terms/alternative -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/alternative"/>
-
-
-
-    <!-- http://purl.org/dc/terms/conformsTo -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/conformsTo"/>
-
-
-
-    <!-- http://purl.org/dc/terms/contributor -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
-
-
-
-    <!-- http://purl.org/dc/terms/created -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/created"/>
-
-
-
-    <!-- http://purl.org/dc/terms/creator -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/creator"/>
-
-
-
-    <!-- http://purl.org/dc/terms/dateCopyrighted -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/dateCopyrighted"/>
-
-
-
-    <!-- http://purl.org/dc/terms/description -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/description">
-        <skos:scopeNote xml:lang="en">This property contains a free-text, individual name of the mobility data platform itself. This property MAY be repeated for parallel language versions of the description - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
-    </owl:AnnotationProperty>
-
-
-
-    <!-- http://purl.org/dc/terms/issued -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/issued"/>
-
-
-
-    <!-- http://purl.org/dc/terms/license -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license">
-        <skos:scopeNote xml:lang="en">This property contains the licence under which the Data Service is made available.</skos:scopeNote>
-    </owl:AnnotationProperty>
-
-
-
-    <!-- http://purl.org/dc/terms/modified -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/modified">
-        <skos:scopeNote xml:lang="en">This property contains the most recent date on which the content of a dataset was changed or modified. This is redundant for high-frequency data services, e.g., via a data feed service, where the change date can be derived from the time stamp within the data feed.</skos:scopeNote>
-    </owl:AnnotationProperty>
-
-
-
-    <!-- http://purl.org/dc/terms/publisher -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/publisher"/>
-
-
-
-    <!-- http://purl.org/dc/terms/rightsHolder -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/rightsHolder"/>
-
-
-
-    <!-- http://purl.org/dc/terms/title -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/title">
-        <skos:scopeNote xml:lang="en">This property contains a name given to the mobility data portal, a name of the Category Scheme, a name given to the Data Service, a name given to the Dataset in a generic term. The name should be a meaningful, unique and unambiguous label. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. The language versions should correspond to property dct:language of class Catalogue Record. I.e., if more than one language is provided as a metadata language, there should be as many language versions for the title.</skos:scopeNote>
-    </owl:AnnotationProperty>
-
-
-
-    <!-- http://purl.org/dc/terms/type -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/type"/>
-
-
-
-    <!-- http://purl.org/ontology/bibo/editor -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/ontology/bibo/editor"/>
-
-
-
-    <!-- http://purl.org/vocab/vann/preferredNamespacePrefix -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/vocab/vann/preferredNamespacePrefix"/>
-
-
-
-    <!-- http://purl.org/vocab/vann/preferredNamespaceUri -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/vocab/vann/preferredNamespaceUri"/>
-
-
-
-    <!-- http://purl.org/vocommons/voaf#reliesOn -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/vocommons/voaf#reliesOn"/>
-
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
-
-
-
-    <!-- http://www.w3.org/2002/07/owl#backwardCompatibleWith -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#backwardCompatibleWith"/>
-
-
-
-    <!-- http://www.w3.org/2003/06/sw-vocab-status/ns#term_status -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2003/06/sw-vocab-status/ns#term_status"/>
-
-
-
-    <!-- http://www.w3.org/2004/02/skos/core#altLabel -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#altLabel"/>
-
-
-
-    <!-- http://www.w3.org/2004/02/skos/core#scopeNote -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#scopeNote"/>
-
-
-
-    <!-- http://www.w3.org/ns/adms#last -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/adms#last"/>
-
-
-
-    <!-- http://www.w3.org/ns/adms#prev -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/adms#prev"/>
-
-
-
-    <!-- http://www.w3.org/ns/adms#representationTechnique -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/adms#representationTechnique"/>
-
-
-
-    <!-- http://www.w3.org/ns/adms#status -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/adms#status"/>
-
-
-
-    <!-- http://www.w3.org/ns/adms#versionNotes -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/adms#versionNotes">
-        <skos:scopeNote xml:lang="en">This property contains a textual description of the differences between this version and a previous version of the dataset, as an addition to the property owl:versionInfo. This property can be repeated for parallel language versions of the version notes - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
-    </owl:AnnotationProperty>
-
-
-
-    <!-- http://www.w3.org/ns/dcat#distribution -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/dcat#distribution"/>
-
-
-
-    <!-- http://www.w3.org/ns/dcat#downloadURL -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/dcat#downloadURL">
-        <skos:scopeNote xml:lang="en">This property contains a URL that is a direct link to a downloadable file in a given format.</skos:scopeNote>
-    </owl:AnnotationProperty>
-
-
-
-    <!-- http://www.w3.org/ns/dcat#mediaType -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/dcat#mediaType"/>
-
-
-
-    <!-- http://www.w3.org/ns/prov#component -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#component"/>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/depiction -->
-
-    <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/depiction"/>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/name -->
-
-    <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/name">
-        <skos:scopeNote xml:lang="en">This property contains a name of the Agent. This property can be repeated for different versions of the name (e.g. the name in different languages) - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
-    </owl:AnnotationProperty>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/page -->
-
-    <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/page"/>
-
-
-
-    <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Datatypes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-
-
-    <!-- http://purl.org/dc/terms/IMT -->
-
-    <rdfs:Datatype rdf:about="http://purl.org/dc/terms/IMT"/>
-
-
-
-    <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Object Properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-
-
-    <!-- http://data.europa.eu/r5r/applicableLegislation -->
-
-    <owl:ObjectProperty rdf:about="http://data.europa.eu/r5r/applicableLegislation">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property MAY refer to one or several legal frameworks being relevant for the dataset, e.g., an EC Delegated Regulation which constitutes the purpose of the corresponding data platform (here called National Access Point/NAP), or some other international or national frameworks, e.g., Open Data regulations. For European legal frameworks, it is recommended to use the European Legislation Identifier [ELI] to refer to legislation whenever possible. This property is derived from the DCAT-AP HVD extension [DCAT-AP-HVD].</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">applicable legislation</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://purl.org/dc/terms/conformsTo -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/conformsTo"/>
-
-
-
-    <!-- http://purl.org/dc/terms/format -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/format">
-        <skos:scopeNote xml:lang="en">This property refers to the technical syntax of the delivered content within the Distribution. It describes the base standard that specifies syntactically correct documents. On this level, only base elements of building documents properly are specified and can be proved by syntax checks. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. The obligation of this property is raised to “mandatory”, compared to [DCAT-AP-v2.0.1]. There is a similar property in [DCAT-AP-v2.0.1] dcat:mediaType, which is removed in mobilityDCAT-AP. There reason is the use of Controlled vocabularies: dct:format uses the EU Authority List [EUV-FT], whereas dcat:mediaType uses the IANA media types [IANA-MEDIA-TYPES]. The first one, however, is sufficient to describe the syntaxes commonly used in mobility data portals. </skos:scopeNote>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://purl.org/dc/terms/identifier -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/identifier"/>
-
-
-
-    <!-- http://purl.org/dc/terms/publisher -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/publisher"/>
-
-
-
-    <!-- http://purl.org/dc/terms/rightsHolder -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/rightsHolder"/>
-
-
-
-    <!-- http://purl.org/dc/terms/temporal -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/temporal">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-        <dcam:rangeIncludes rdf:resource="http://purl.org/dc/terms/PeriodOfTime"/>
-        <rdfs:comment xml:lang="en">This property describes the beginning and end of the time interval when a data service, e.g., a data feed, is delivered technically via the data platform. If there is no entry it means that the publication gets valid immediately and the timestamp is the same as the metadata timestamp.  </rdfs:comment>
-        <rdfs:label xml:lang="en">temporal coverage</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">This property refers to a temporal period, i.e., the beginning and the end, of the time reference of the delivered content (e.g., validity time of a public-transport time table).</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://purl.org/dc/terms/type -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/type"/>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#applicationLayerProtocol -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#applicationLayerProtocol">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property describes the transmitting channel, i.e., the Application Layer Protocol, of the distribution. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. </rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">application layer protocol</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this property is recommended to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#assessmentResult -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#assessmentResult">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#Assessment"/>
-        <rdfs:comment xml:lang="en">This property MAY refer to the results and outcomes from an assessment process by some organisation, e.g., a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance of the Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies [NAPCORE-NB] and installed individually in each Member State. The property MAY point to the most recent assessment procedure, including its date, its result as a free-text and/or a link referring to an assessment report online. The difference to the property dqv:hasQualityAnnotation is that the latter one is provided by the data provider, while the assessment results are provided by an external organisation. </rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">assessment result</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#communicationMethod -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#communicationMethod">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property indicates for data services, e.g., data feeds, if the data interface of the data provider system functions in a push or pull mode. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">communication method</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#georeferencingMethod -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#georeferencingMethod">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property SHOULD be used to specify the georeferencing method used in the dataset. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided, denoting commonly used georeferencing methods for mobility data.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">georeferencing method</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#grammar -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#grammar">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/conformsTo"/>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property describes the technical data grammar format of the delivered content within the Distribution. It describes the standard on top of the elementary syntax that describe data structures in the dataset. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. This is a sub-property of dct:conformsTo.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">grammar</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#intendedInformationService -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#intendedInformationService">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property MAY describe predefined information services, which the data content is intended to support. Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR]. Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">intended information service</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#mobilityDataStandard -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#mobilityDataStandard">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/format"/>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-        <dcam:rangeIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
-        <rdfs:comment xml:lang="en">This property describes the mobility data standard, as applied for the delivered content within the Distribution. A mobility data standard, e.g., DATEX II, combines syntax and semantic definitions of entities in a certain domain (e.g., for DATEX II: road traffic information), and optionally adds technical rules for data exchange. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided, listing common mobility data standards. If no established mobility data standard is applied, an information “proprietary standard” is requested. </rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">mobility data standard</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#mobilityTheme -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#mobilityTheme">
-        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/dcat#theme"/>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content. A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content. The theme is described via a controlled vocabulary in two hierarchy levels: The 1st level is a mandatory field labelled “Data content category, describing the classification of the data content on an aggregated level. The 2nd level is an optional field labelled “Data content sub category”, detailing the “Data content category” via one or several sub-categories. When entering the metadata for one dataset, the data provider would first select one or several options of a “Data content category”, and then optionally details this with one or more options of corresponding “Data content sub category”. The platform must be able to handle the dependencies between these two levels, i.e., match the allowed options between the 1st and 2nd level. The corresponding controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. This property is a sub-property of dcat:theme, which is also a further, recommended property of Dataset. To distinguish the both theme properties, it is recommended to label mobilitydcatap:mobilityTheme as “Mobility Theme”, and dcat:theme as “EU Open Data Theme”. The subject of a dataset MAY also be described via a property dcat:keyword. However, the usage of “theme / category” is preferred, to avoid ambiguity and uncontrolled theme descriptions.</rdfs:comment>
-        <rdfs:label xml:lang="en">mobility theme</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for  Dataset.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#networkCoverage -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#networkCoverage">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed. For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data. For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T]. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided, denoting commonly used road and infrastructure network classes.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">network coverage</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#schema -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#schema">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/conformsTo"/>
-        <dcam:domainIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
-        <rdfs:comment xml:lang="en">This property describes the schema of the mobility data standard, as applied within the delivered content. There are differet optiions how to reference the schema. It might be a reference to a portal-internal catalogue of schemas, a reference to an individual schema (that is provided by the data publisher), or a reference to an external catalogue of schemas (like a stakeholder-based DATEX II profile published on the datex2.eu page). The data platform SHOULD keep an archive of commonly used schemas. The data provider SHOULD be able to select an applicable schema from this archive, or to upload an own, individual schema. In any case, the schema should be available as a resource. This is a sub-property of dct:conformsTo.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">schema</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#transportMode -->
-
-    <owl:ObjectProperty rdf:about="http://w3id.org/mobilitydcat-ap#transportMode">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided, denoting commonly used transport modes.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">transportation mode</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/2004/02/skos/core#inScheme -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2004/02/skos/core#inScheme">
-        <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/Location"/>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-        <rdfs:comment xml:lang="en">This property MAY be used to specify the Category Scheme to which the Category belongs. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:comment xml:lang="en">This property MAY be used to specify the gazetteer to which the Location belongs. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:label xml:lang="en">category scheme</rdfs:label>
-        <rdfs:label xml:lang="en">gazetteer</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for  Location.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for  Category.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/2006/vcard/ns#hasAddress -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2006/vcard/ns#hasAddress">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>
-        <rdfs:comment xml:lang="en">This property MAY be used to specify the postal address of the Kind. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].  </rdfs:comment>
-        <rdfs:label xml:lang="en">address</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/2006/vcard/ns#hasEmail -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2006/vcard/ns#hasEmail">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:comment xml:lang="en">This property contains an email address of the Kind, specified using fully qualified mailto: URI scheme [RFC6068]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].  </rdfs:comment>
-        <rdfs:label xml:lang="en">email</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/2006/vcard/ns#hasTelephone -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2006/vcard/ns#hasTelephone">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:comment xml:lang="en">This property MAY be used to provide the phone number of the Kind, specified using fully qualified tel: URI scheme [RFC3966]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
-        <rdfs:label xml:lang="en">phone</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/2006/vcard/ns#hasURL -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/2006/vcard/ns#hasURL">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:comment xml:lang="en">This property points to a Web site of the Kind. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].  </rdfs:comment>
-        <rdfs:label xml:lang="en">URL</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/ns/adms#identifier -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/adms#identifier">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Catalog"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/adms#Identifier"/>
-        <rdfs:comment xml:lang="en">This property MAY be used as an additional identifier, besides dct:identifier. It MAY be referring to a dedicated, EU-wide identificator system of NAPS or other portals, to be introduced in the future.</rdfs:comment>
-        <rdfs:label xml:lang="en">other identifier</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Catalogue. </skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/ns/adms#sample -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/adms#sample">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
-        <rdfs:comment xml:lang="en">This property refers to a sample Distribution of the Dataset. A data sample allows data users to investigate the data content and data structure, without subscribing to a data feed or downloading a complete data set. In [DCAT-AP-v2.0.1], there is a property adms:sample under the class dcat:Dataset , with a range of dcat:Distribution. This implies, that all mandatory properties from dcat:Distribution, e.g., mobilitydcatap:mobilityDataStandard, must be applied. To simplify the description of the Sample, mobilityDCAT-AP recommends to describe the Sample via a property under class dcat:Distribution. It is assumed that all other properties, as already populated for dcat:Distribution, e.g., mobilitydcatap:mobilityDataStandard, also apply for the description of the data sample.  </rdfs:comment>
-        <rdfs:label xml:lang="en">sample</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/ns/dcat#theme -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#theme">
-        <skos:scopeNote xml:lang="en">The values to be used for this property are the URIs of the concepts in the vocabulary. This is a vocabulary created by mobilityDCAT-AP. There are two hierarchical levels: &apos;&apos;Data content category&apos;&apos; (mandatory) and &apos;&apos;Data content sub-category&apos;&apos; (optional), see the usage note for property &apos;&apos;dcat:theme&apos;&apos;.</skos:scopeNote>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/ns/dqv#hasQualityAnnotation -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dqv#hasQualityAnnotation">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/dqv#QualityAnnotation"/>
-        <rdfs:comment xml:lang="en">This property MAY describe any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Rights Holder (see property dct:rightsHolder). This information SHOULD assist data consumers in determining the value of data, before actually accessing and processing it. Thus, the information SHOULD be publicly available. Furthermore, it can be helpful for validation processes by 3rd parties, e.g., a National Body in context of EU Delegated Regulations. Quality aspects SHOULD be noted via a free text and/or via URLs linking to further quality information. If there is absolutely no quality information, at least a note “quality information is unknown” SHOULD be given. If existing quality frameworks have been applied in the quality assessment, e.g., the Quality Packages from the EU EIP and NAPCORE projects [EU-EIP-QP], these frameworks should be referenced.  </rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">quality description</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/ns/locn#address -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/locn#address">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <rdfs:comment xml:lang="en">This property MAY be used to specify the postal address of the Agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:label xml:lang="en">address</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/ns/oa#hasBody -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/oa#hasBody"/>
-
-
-
-    <!-- http://www.w3.org/ns/oa#hasTarget -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/oa#hasTarget">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dqv#QualityAnnotation"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <rdfs:comment xml:lang="en">This property MAY be used to describe the target of the quality annotation, referring back to the dataset being described. I.e., it is the inverse property of “dqv:hasQualityAnnotation” for class Dataset.</rdfs:comment>
-        <rdfs:label xml:lang="en">quality annotation target</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Quality Annotation. </skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://www.w3.org/ns/org#memberOf -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/org#memberOf">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/org#Organization"/>
-        <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the affiliation of the Agent, see § 7. Agent Types, Agent Roles and Contact Information. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:label xml:lang="en">affiliation</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/mbox -->
-
-    <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/mbox">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:comment xml:lang="en">This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:label xml:lang="en">email</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/phone -->
-
-    <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/phone">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:comment xml:lang="en">This property MAY be used to provide the phone number of the Agent, specified using fully qualified tel: URI scheme [RFC3966]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:label xml:lang="en">phone</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/workplaceHomepage -->
-
-    <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/workplaceHomepage">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
-        <rdfs:comment xml:lang="en">This property MAY be used to specify the Web site of the Agent.</rdfs:comment>
-        <rdfs:label xml:lang="en">URL</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:ObjectProperty>
-
-
-
-    <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Data properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-
-
-    <!-- http://purl.org/dc/terms/created -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.org/dc/terms/created"/>
-
-
-
-    <!-- http://purl.org/dc/terms/identifier -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.org/dc/terms/identifier"/>
-
-
-
-    <!-- http://purl.org/dc/terms/issued -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.org/dc/terms/issued"/>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#dataFormatNotes -->
-
-    <owl:DatatypeProperty rdf:about="http://w3id.org/mobilitydcat-ap#dataFormatNotes">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">This property contains any additional information about the format of the delivered content within the Distribution (see the corresponding properties dct:format, mobilitydcatap:mobilityDataStandard, mobilitydcatap:grammar), in a textual format. This might be about, e.g., extensions being used in a mobilitydcatap:mobilityDataStandard. </rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">data format notes</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
-
-
-
-    <!-- http://www.w3.org/2002/07/owl#versionInfo -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2002/07/owl#versionInfo"/>
-
-
-
-    <!-- http://www.w3.org/2004/02/skos/core#prefLabel -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel">
-        <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/Location"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">This property contains a preferred label of the Location. This property can be repeated for parallel language versions of the label - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:label xml:lang="en">geographic name</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Location.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">This property contains a preferred label of the Category. This property can be repeated for parallel language versions of the label - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/2006/vcard/ns#fn -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#fn">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">This property contains a name of the Kind. This property can be repeated for different versions of the name (e.g., the name in different languages) - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
-        <rdfs:label xml:lang="en">name</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/2006/vcard/ns#organization-name -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#organization-name">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">This property MAY be used to specify the affiliation of the Kind. This property can be repeated for different versions of the name (e.g. the name in different languages) - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
-        <rdfs:label xml:lang="en">affiliation</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/2011/content#characterEncoding -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/2011/content#characterEncoding">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">This property describes the technical encoding format of the delivered content within the Distribution. It SHOULD be expressed using a character set name defined in the IANA register [IANA-CHARSETS]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. This is a sub-property of dct:conformsTo. </rdfs:comment>
-        <rdfs:label xml:lang="en">character encoding</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/ns/locn#adminUnitL1 -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/locn#adminUnitL1">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">The country of an Address of the Agent.</rdfs:comment>
-        <rdfs:label xml:lang="en">country</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/ns/locn#adminUnitL2 -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/locn#adminUnitL2">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">The administrative area of an Address of the Agent. Depending on the country, this corresponds to a province, a county, a region, or a state.</rdfs:comment>
-        <rdfs:label xml:lang="en">administrative area</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/ns/locn#postCode -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/locn#postCode">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">The postal code of an Address of the Agent.</rdfs:comment>
-        <rdfs:label xml:lang="en">postal code</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/ns/locn#postName -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/locn#postName">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">The city of an Address of the Agent.</rdfs:comment>
-        <rdfs:label xml:lang="en">city</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/ns/locn#thoroughfare -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/locn#thoroughfare">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">The street name and civic number of an Address of the Agent.</rdfs:comment>
-        <rdfs:label xml:lang="en">street address</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://www.w3.org/ns/oa#hasBody -->
-
-    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/oa#hasBody"/>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/firstName -->
-
-    <owl:DatatypeProperty rdf:about="http://xmlns.com/foaf/0.1/firstName">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the first name of the Agent, see section § 7. Agent Types, Agent Roles and Contact Information.</rdfs:comment>
-        <rdfs:label xml:lang="en">first name</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/surname -->
-
-    <owl:DatatypeProperty rdf:about="http://xmlns.com/foaf/0.1/surname">
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the surname of the Agent, see section 7.</rdfs:comment>
-        <rdfs:label xml:lang="en">surname</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:DatatypeProperty>
-
-
-
-    <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Classes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-
-
-    <!-- http://purl.org/dc/terms/Standard -->
-
-    <owl:Class rdf:about="http://purl.org/dc/terms/Standard">
-        <skos:scopeNote xml:lang="en">A standard or other specification to which a Catalogue, Catalogue Record, Data Service, Dataset, or Distribution conforms.. This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is used as the range of property &apos;&apos;dct:conformsTo&apos;&apos; for class Catalogue Record (context &apos;&apos;application profile&apos;&apos;); for class Dataset (context&apos; &apos;conforms to&apos;&apos;); and for class Distribution (context &apos;&apos;linked schemas&apos;&apos;). In mobilityDCAT-AP, these properties are removed. However, mobilityDCAT-AP uses this class as the range of an added property &apos;&apos;dct:conformsTo&apos;&apos; for class Dataset in a different context &apos;&apos;reference system&apos;&apos;, analogue to a property addition by [GEODCAT-AP-v2.0.0]. [GEODCAT-AP-v2.0.0] adds several properties to the class Standard. These describe any standards via an identifier, type, release date etc. However, describing standards is not a main use case of mobilityDCAT-AP, so no properties are added here. If necessary, the properties for class Standard, as added by [GEODCAT-AP-v2.0.0], MAY be used.</skos:scopeNote>
-    </owl:Class>
-
-
-
-    <!-- http://purl.org/vocommons/voaf#Vocabulary -->
-
-    <owl:Class rdf:about="http://purl.org/vocommons/voaf#Vocabulary"/>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#Assessment -->
-
-    <owl:Class rdf:about="http://w3id.org/mobilitydcat-ap#Assessment">
-        <rdfs:comment xml:lang="en">An assessment procedure by an external organisation. This organisation MAY be a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance with the applicable Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies [NAPCORE-NB] and installed individually in each Member State. The information is optional and needed for the documentation of the assessment procedure. It MAY be an internal information, only visible for assessment organisations or other authorised users.  </rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">Assessment</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:Class>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap#MobilityDataStandard -->
-
-    <owl:Class rdf:about="http://w3id.org/mobilitydcat-ap#MobilityDataStandard">
-        <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/Standard"/>
-        <rdfs:comment xml:lang="en">The mobility data standard applied for the delivered content. A mobility data standard, e.g., DATEX II, combines syntax and semantic definitions of entities in a certain domain (e.g., for DATEX II: road traffic information), and optionally adds technical rules for data exchange. This is a sub-class of dct:Standard.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://w3id.org/mobilitydcat-ap#"/>
-        <rdfs:label xml:lang="en">Mobility Data Standard</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory class.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:Class>
-
-
-
-    <!-- http://www.w3.org/ns/adms#Asset -->
-
-    <owl:Class rdf:about="http://www.w3.org/ns/adms#Asset"/>
-
-
-
-    <!-- http://www.w3.org/ns/adms#AssetDistribution -->
-
-    <owl:Class rdf:about="http://www.w3.org/ns/adms#AssetDistribution"/>
-
-
-
-    <!-- http://www.w3.org/ns/dqv#QualityAnnotation -->
-
-    <owl:Class rdf:about="http://www.w3.org/ns/dqv#QualityAnnotation">
-        <rdfs:comment xml:lang="en">An annotation about any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Data Owner. There is a similar class  “Quality Measurement” in [GEODCAT-AP-v2.0.0]. Both  “Quality Annotation” are  “Quality Measurement” are reusing the Data Quality Vocabulary [VOCAB-DQV]. Quality Measurement is referring to concrete metrics, like sub-types of spatial resolutions being used [GEODCAT-AP-v2.0.0]. At mobility data portals, however, the practice so far is to provide some free text about quality aspects. Thus, the Quality Annotation refers to an unspecified form of quality annotation, which MAY be a free text. </rdfs:comment>
-        <rdfs:label xml:lang="en">Quality Annotation</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:Class>
-
-
-
-    <!-- http://www.w3.org/ns/locn#Address -->
-
-    <owl:Class rdf:about="http://www.w3.org/ns/locn#Address">
-        <rdfs:comment xml:lang="en">A postal address of the Agent.A postal address of the Agent. </rdfs:comment>
-        <rdfs:label xml:lang="en">Address (Agent)</rdfs:label>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </owl:Class>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/Group -->
-
-    <owl:Class rdf:about="http://xmlns.com/foaf/0.1/Group"/>
-
-
-
-    <!-- http://xmlns.com/foaf/0.1/Person -->
-
-    <owl:Class rdf:about="http://xmlns.com/foaf/0.1/Person"/>
-
-
-
-    <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Individuals
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-
-
-    <!-- http://data.europa.eu/r5r/ -->
-
-    <owl:NamedIndividual rdf:about="http://data.europa.eu/r5r/"/>
-
-
-
-    <!-- http://publications.europa.eu/resource/authority/asset-classification/c_89b4bdb7 -->
-
-    <owl:NamedIndividual rdf:about="http://publications.europa.eu/resource/authority/asset-classification/c_89b4bdb7"/>
-
-
-
-    <!-- http://publications.europa.eu/resource/authority/corporate-body/COM -->
-
-    <owl:NamedIndividual rdf:about="http://publications.europa.eu/resource/authority/corporate-body/COM"/>
-
-
-
-    <!-- http://publications.europa.eu/resource/authority/dataset-type/APROF -->
-
-    <owl:NamedIndividual rdf:about="http://publications.europa.eu/resource/authority/dataset-type/APROF"/>
-
-
-
-    <!-- http://publications.europa.eu/resource/authority/dataset-type/ONTOLOGY -->
-
-    <owl:NamedIndividual rdf:about="http://publications.europa.eu/resource/authority/dataset-type/ONTOLOGY"/>
-
-
-
-    <!-- http://publications.europa.eu/resource/authority/file-type/HTML -->
-
-    <owl:NamedIndividual rdf:about="http://publications.europa.eu/resource/authority/file-type/HTML"/>
-
-
-
-    <!-- http://publications.europa.eu/resource/authority/file-type/JSON_LD -->
-
-    <owl:NamedIndividual rdf:about="http://publications.europa.eu/resource/authority/file-type/JSON_LD"/>
-
-
-
-    <!-- http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE -->
-
-    <owl:NamedIndividual rdf:about="http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE"/>
-
-
-
-    <!-- http://publications.europa.eu/resource/authority/file-type/RDF_XML -->
-
-    <owl:NamedIndividual rdf:about="http://publications.europa.eu/resource/authority/file-type/RDF_XML"/>
-
-
-
-    <!-- http://w3id.org/mobilitydcat-ap# -->
-
-    <owl:NamedIndividual rdf:about="http://w3id.org/mobilitydcat-ap#">
-        <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
-        <rdf:type rdf:resource="http://www.w3.org/ns/adms#Asset"/>
-        <dct:conformsTo rdf:resource="http://data.europa.eu/r5r/"/>
-        <dct:conformsTo rdf:resource="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements"/>
-        <dct:conformsTo rdf:resource="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/document/change-and-release-management-policy-dcat-ap"/>
-        <dct:conformsTo rdf:resource="https://www.w3.org/TR/vocab-dcat-2/"/>
-        <dct:publisher rdf:resource="https://napcore.eu/"/>
-        <dct:rightsHolder rdf:resource="https://napcore.eu/"/>
-        <dct:type rdf:resource="http://publications.europa.eu/resource/authority/asset-classification/c_89b4bdb7"/>
-        <dct:type rdf:resource="http://publications.europa.eu/resource/authority/dataset-type/APROF"/>
-        <dct:type rdf:resource="http://publications.europa.eu/resource/authority/dataset-type/ONTOLOGY"/>
-    </owl:NamedIndividual>
-
-
-
-    <!-- http://www.w3.org/ns/formats/data/JSON-LD -->
-
-    <owl:NamedIndividual rdf:about="http://www.w3.org/ns/formats/data/JSON-LD"/>
-
-
-
-    <!-- http://www.w3.org/ns/formats/data/RDF_XML -->
-
-    <owl:NamedIndividual rdf:about="http://www.w3.org/ns/formats/data/RDF_XML"/>
-
-
-
-    <!-- http://www.w3.org/ns/formats/data/Turtle -->
-
-    <owl:NamedIndividual rdf:about="http://www.w3.org/ns/formats/data/Turtle"/>
-
-
-
-    <!-- https://eur-lex.europa.eu/eli/reg/2008/1205/2008-12-24 -->
-
-    <owl:NamedIndividual rdf:about="https://eur-lex.europa.eu/eli/reg/2008/1205/2008-12-24"/>
-
-
-
-    <!-- https://github.com/lcomet -->
-
-    <owl:NamedIndividual rdf:about="https://github.com/lcomet">
-        <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
-        <foaf:name>Lina Molinas Comet</foaf:name>
-    </owl:NamedIndividual>
-
-
-
-    <!-- https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements -->
-
-    <owl:NamedIndividual rdf:about="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements"/>
-
-
-
-    <!-- https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/document/change-and-release-management-policy-dcat-ap -->
-
-    <owl:NamedIndividual rdf:about="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/document/change-and-release-management-policy-dcat-ap"/>
-
-
-
-    <!-- https://napcore.eu/ -->
-
-    <owl:NamedIndividual rdf:about="https://napcore.eu/"/>
-
-
-
-    <!-- https://w3id.org/mobilitydcatap/ -->
-
-    <owl:NamedIndividual rdf:about="https://w3id.org/mobilitydcatap/">
-        <dct:conformsTo rdf:resource="http://data.europa.eu/r5r/"/>
-        <dct:conformsTo rdf:resource="https://eur-lex.europa.eu/eli/reg/2008/1205/2008-12-24"/>
-        <dct:conformsTo rdf:resource="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements"/>
-        <dct:conformsTo rdf:resource="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/document/change-and-release-management-policy-dcat-ap"/>
-        <dct:conformsTo rdf:resource="https://www.w3.org/TR/vocab-dcat-2/"/>
-        <dct:publisher rdf:resource="http://publications.europa.eu/resource/authority/corporate-body/COM"/>
-    </owl:NamedIndividual>
-
-
-
-    <!-- https://www.w3.org/TR/vocab-dcat-2/ -->
-
-    <owl:NamedIndividual rdf:about="https://www.w3.org/TR/vocab-dcat-2/"/>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Group"/>
-        <foaf:name>NAPCORE SWG 4.4</foaf:name>
-        <foaf:page rdf:resource="https://github.com/mobilityDCAT-AP/mobilityDCAT-AP"/>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
-        <foaf:name>Lina Molinas Comet</foaf:name>
-    </rdf:Description>
-    <rdf:Description rdf:nodeID="genid3">
-        <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
-        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/JSON_LD"/>
-        <dct:format rdf:resource="http://www.w3.org/ns/formats/data/JSON-LD"/>
-        <dct:title xml:lang="en">JSON-LD</dct:title>
-        <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
-        <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
-        <dcat:downloadURL rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.jsonld"/>
-        <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/application/ld+json"/>
-    </rdf:Description>
-    <rdf:Description rdf:nodeID="genid4">
-        <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
-        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE"/>
-        <dct:format rdf:resource="http://www.w3.org/ns/formats/data/Turtle"/>
-        <dct:title xml:lang="en">Turtle</dct:title>
-        <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
-        <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
-        <dcat:downloadURL rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.ttl"/>
-        <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
-    </rdf:Description>
-    <rdf:Description rdf:nodeID="genid5">
-        <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
-        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/RDF_XML"/>
-        <dct:format rdf:resource="http://www.w3.org/ns/formats/data/RDF_XML"/>
-        <dct:title xml:lang="en">RDF/XML</dct:title>
-        <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
-        <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
-        <dcat:downloadURL rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.rdf"/>
-        <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
-    </rdf:Description>
-    <rdf:Description rdf:nodeID="genid6">
-        <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
-        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/HTML"/>
-        <dct:title xml:lang="en">HTML</dct:title>
-        <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/HumanLanguage"/>
-        <dcat:downloadURL rdf:resource="http://w3id.org/mobilitydcat-ap/releases/1.0.0/"/>
-        <dcat:mediaType rdf:datatype="http://purl.org/dc/terms/IMT">text/html</dcat:mediaType>
-    </rdf:Description>
-
-
-
-    <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotations
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    <rdf:Description rdf:about="http://purl.org/dc/terms/LicenseDocument">
-        <skos:scopeNote xml:lang="en">A legal document giving official permission to do something with a resource. The &apos;&apos;dct:identifier&apos;&apos; recommended property is not included in [DCAT-AP-v2.0.1]. The licence type recommended property is removed from [DCAT-AP-v2.0.1]. The &apos;&apos;rdfs:label&apos;&apos; optional property is not included in [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/Location">
-        <skos:scopeNote xml:lang="en">A spatial region or named place. It can be represented via a named place (controlled vocabulary) or with geographic coordinates, according to DCAT-AP guidelines [DCAT-AP-guideline-spatial]. For mobility data portals, usage of a named place is preferred. Many mobility data providers represent public authorities such as states, regions, municipalities etc., which can be easily represented via named places. In contrast, defining of coordinates per data set might be error-prone and inconsistent. As named spaces, identifiers SHOULD be used (via property &apos;&apos;dct:identifier&apos;&apos;). These are coded via controlled vocabularies such as the EU authority tables, NUTS (Nomenclature des unités territoriales statistiques) or Geonames, see § 5.2 Controlled vocabularies to be used. Alternatively, geographic clear names MAY be used via property &apos;&apos;skos:prefLabel&apos;&apos;. The &apos;&apos;skos:inScheme&apos;&apos; and &apos;&apos;dct:identifier&apos;&apos; recommended properties are not included in [DCAT-AP-v2.0.1]. The &apos;&apos;skos:prefLabel&apos;&apos; optional property is not included in [DCAT-AP-v2.0.1]. Please note that the order of usage is as follows: use the most specific geospatial relationship by preference. E.g. if the spatial description is a bbox, use &apos;&apos;dcat:bbox&apos;&apos;, otherwise use &apos;&apos;locn:geometry&apos;&apos; (see § 4.16.2 Optional properties for Location).</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/MediaType">
-        <skos:scopeNote xml:lang="en"> A media type, e.g. the format of a computer file. This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is only used as the range of the optional properties &apos;&apos;dcat:compressFormat&apos;&apos;, &apos;&apos;dcat:mediaType&apos;&apos;, and &apos;&apos;dcat:packageFormat&apos;&apos; for class Distribution. In mobilityDCAT-AP, however, these properties are removed. Thus, this class SHOULD NOT be used but is kept for compatibility reasons with [DCAT-AP-v2.0.1]</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/PeriodOfTime">
-        <skos:scopeNote xml:lang="en">An interval of time that is named or defined by its start and end dates. Please note that while both properties are recommended, one of the two must be present for each instance of the class &apos;&apos;dct:PeriodOfTime&apos;&apos;, if such an instance is present. The start of the period should be understood as the start of the date, hour, minute etc. given (e.g. starting at midnight at the beginning of the day if the value is a date); the end of the period should be understood as the end of the date, hour, minute etc. given (e.g. ending at midnight at the end of the day if the value is a date). The beginning and end properties are removed from [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/ProvenanceStatement">
-        <skos:scopeNote xml:lang="en">A statement of any changes in ownership and custody of a resource since its creation that are significant for its authenticity, integrity, and interpretation. This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is only used as the range of the optional property &apos;&apos;dct:provenance&apos;&apos; for class Dataset. In mobilityDCAT-AP, however, this property is removed. Thus, this class SHOULD NOT be used but is kept for compatibility reasons with [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/RightsStatement">
-        <skos:scopeNote xml:lang="en">A statement about the intellectual property rights (IPR) held in or over a resource, a legal document giving official permission to do something with a resource, or a statement about access rights. As a minimum, it should include an information on the type of conditions for access and usage. Information about concrete licenses can be provided via class License Document. The &apos;&apos;dct:type&apos;&apos; mandatory property is not included in [DCAT-AP-v2.0.1]. The &apos;&apos;rdfs:label&apos;&apos; recommended property is not included in [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/accessRights">
-        <skos:scopeNote xml:lang="en">This property MAY include information regarding access or restrictions based on privacy, security, or other policies. For INSPIRE metadata, this property SHOULD be used with the URIs of the &apos;&apos;Limitations on public access&apos;&apos; code list operated by the INSPIRE Registry [INSPIRE-LPA].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/accrualPeriodicity">
-        <skos:scopeNote xml:lang="en">This property describes how often the delivered content is updated. This information tells a data consumer, how often it is updated on the on the data platform, so the data consumer might align the frequency of data retrieval accordingly. For data services, e.g., data feeds, the frequency should correspond to the technical upload / data push frequency. For static data sets, it should correspond to the expected change frequency (see property dct:modified). The frequency might be a specific time interval, or a general remark such as “updated on occurrence”. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. The obligation of this property is raised to “mandatory”, compared to [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/conformsTo">
-        <rdfs:label xml:lang="en">reference system</rdfs:label>
-        <rdfs:comment xml:lang="en">This property SHOULD be used to specify the spatial reference system used in the dataset. Spatial reference systems SHOULD be specified by using the corresponding URIs from the “EPSG coordinate reference systems” register operated by OGC [OGC-EPSG]. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Dataset. </skos:scopeNote>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://purl.org/dc/terms/Standard"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/created">
-        <rdfs:comment xml:lang="en">This property contains the date stamp (date and time) when the metadata entry was created for the first time. It SHOULD be generated by the system, whenever a platform user enters the metadata entry. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
-        <rdfs:label xml:lang="en">creation date</rdfs:label>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Catalogue Record. Its range is rdfs:Literal typed as xsd:date or xsd:dateTime. </skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/hasPart">
-        <skos:scopeNote xml:lang="en">This property refers to a related Catalogue that is part of the described mobility data portal. This property could be used to link the mobility data portal to another data portal, by e.g. harvesting metadata from this other portal into the mobility data portal. </skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/hasVersion">
-        <skos:scopeNote xml:lang="en">This property refers to a related dataset that is a version, edition, or adaptation of the described dataset. Corresponds to the property &apos;&apos;dct:isVersionOf&apos;&apos;, with a contrary relationship. It might be used to host multiple versions of the same data set in the data portal, also enabling a version history. Multiple versions should be differentiated via the properties &apos;&apos;owl:versionInfo&apos;&apos; and &apos;&apos;adms:versionNotes&apos;&apos;.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/identifier">
-        <vs:term_status>stable</vs:term_status>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-        <rdfs:comment xml:lang="en">This property MAY contain an identifier for the mobility data portal. Allows a unique identification of the individual portal and is used for referencing, e.g., when exchanging metadata between mobility data portals. This property SHOULD populated by the URI used within the RDF statement (via rdf:about). This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:comment xml:lang="en">This property MAY be be used to link to a concrete standard license. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.  </rdfs:comment>
-        <rdfs:label xml:lang="en">standard licence</rdfs:label>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Licence Document </skos:scopeNote>
-        <rdfs:comment xml:lang="en">This property contains the geographic identifier for the Location, e.g., the URI or other unique identifier in the context of the relevant gazetteer. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <rdfs:label xml:lang="en">identifier</rdfs:label>
-        <rdfs:label xml:lang="en">geographic identifier</rdfs:label>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Catalog"/>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Location.</skos:scopeNote>
-        <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/Location"/>
-        <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/LicenseDocument"/>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Catalogue. </skos:scopeNote>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/isPartOf">
-        <skos:scopeNote xml:lang="en">This property refers to a related Catalogue in which the described mobility data portal is physically or logically included. This property could be used to link the mobility data portal to another data portal, by e.g. harvesting metadata from the mobility data portal into this other portal. </skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/isReferencedBy">
-        <skos:scopeNote xml:lang="en">This property references, cites, or otherwise points to another, related dataset. Corresponds to the property dct:relation, with a contrary relationship. It may be a link between two individual datasets that complement each other, e.g. one dataset with static parking data, and one with dynamic parking data, both covering the same parking facilities.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/isVersionOf">
-        <skos:scopeNote xml:lang="en">This property refers to a related dataset of which the described dataset is a version, edition, or adaptation. Corresponds to property dct:hasVersion with contrary relationship. It might be used to host multiple versions of the same data set in the data portal, also enabling a version history. Multiple versions should be differentiated via the properties owl:versionInfo and adms:versionNotes.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/issued">
-        <dcam:domainIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#Assessment"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <rdfs:label xml:lang="en">assessment date</rdfs:label>
-        <skos:scopeNote xml:lang="en">This property contains the date of formal issuance (e.g., publication) of the Catalogue.</skos:scopeNote>
-        <rdfs:comment xml:lang="en">This property MAY be used to describe the date of the latest assessment procedure.</rdfs:comment>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Assessment. Its range is rdfs:Literal typed as xsd:date or xsd:dateTime. </skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/language">
-        <skos:scopeNote xml:lang="en">This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the metadata entry. The value should be generated automatically by the NAP system, corresponding to the currently used language in the user interface. Some portals offer multilingual user interfaces, e.g., in the local language and additionally in English. For multiple languages - see § 8. Accessibility and Multilingual Aspects. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/publisher">
-        <dcam:rangeIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-        <rdfs:comment xml:lang="en">This property refers to an entity (an organisation or a person), which is responsible for creation and maintenance of the metadata entry on the data platform. This entity is the direct contact for the data platform operators or data-searching users, who have questions or issues about the metadata entry. This information can be natively created by a data platform, then corresponding to the entity that is registered to the data platform and has the role of a metadata creator. This information can be also harvested from other portals. It should include, as a minimum, the name and email address of the entity. The information might be identical to the property “Publisher” of the corresponding dataset. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
-        <rdfs:label xml:lang="en">publisher</rdfs:label>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Catalogue Record.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/source">
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-        <rdfs:comment xml:lang="en">This property is used for metadata records that are harvested from other portals. Harvesting, i.e., the automated import of metadata information from external portals, seems to be a common case for some NAPs. With these property, a data user can see, if the metadata was harvested, and from where. The property SHOULD link to a public URL of the dataset descripton on the original data portal, from where the metadata was harvested.</rdfs:comment>
-        <rdfs:label xml:lang="en">source metadata</rdfs:label>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Catalogue Record.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/relation">
-        <skos:scopeNote xml:lang="en">This property references, cites, or otherwise points to another, related dataset. Corresponds to the property dct:isReferencedBy, with contrary relationship. It may be a link between two individual datasets that complement each other, e.g. one dataset with static parking data, and one with dynamic parking data, both covering the same parking facilities.	</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/rights">
-        <skos:scopeNote xml:lang="en">This property links to a Rights Statement, i.e., a statement about the intellectual property rights (IPR). As a minimum, it should include an information on the type of conditions for access and usage. A concrete (standard) license can be referred via the recommended property dct:license. The obligation of this property is raised to “mandatory”, compared to [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/rightsHolder">
-        <rdfs:comment xml:lang="en">This property refers to an entity that legally owns or holds the rights of the data provided in a dataset. This entity is legally responsible for the content of the data. It is also responsible for any statements about the data quality (if applicable, see property dqv:hasQualityAnnotation) and/or the relevance to legal frameworks (if applicable, see property dcatap:applicableLegislation). This entity is the direct contact for the platform operator or data consumers, who have questions or issues about the contents of a dataset. The Rights Holder will be in many cases identical with the Publisher information for class Dataset (see property dct:publisher) and/or for class Catalogue Record (see property dct:publisher). In this case, the contact data MAY be copied from the corresponding Publisher entries. There might be also cases with non-identical entities: e.g., when one or several Rights Holders contract a third-party Publisher (e.g., an IT service company), which is producing, hosting and publishing a dataset. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Dataset. </skos:scopeNote>
-        <vs:term_status>stable</vs:term_status>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-        <dcam:rangeIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
-        <rdfs:label xml:lang="en">rights holder</rdfs:label>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/spatial">
-        <skos:scopeNote xml:lang="en">This property refers to a country code where the data platform is hosted. For National Access Points (NAPs), this corresponds to the EC Member State or a country that installs such NAP. The property might be used for analyses about available data sets per country, or to identify country-specific metadata in case metadata are federated from multiple national portals into an international portal. It is not to be mixed up with country codes used within the dataset property dct:spatial, which might be different. The obligation of this property is raised to “mandatory”, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/type">
-        <rdfs:label xml:lang="en">conditions for access and usage</rdfs:label>
-        <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/RightsStatement"/>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">This property refers to a type of the Agent that makes the Catalogue, Catalogue Record, Data Service, or Dataset available</skos:scopeNote>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <rdfs:comment xml:lang="en">This property SHOULD be used to indicate the conditions if any contracts, licences and/or are applied for the use of the dataset. The conditions are declared on an aggregated level: whether a free and unrestricted use is possible, a contract has to be concluded and/or a licence has to be agreed on to use a dataset. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. The values can be logically mapped with the property dct:identifier from class dct:LicenseDocument. </rdfs:comment>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Rights Statement.</skos:scopeNote>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://spdx.org/rdf/terms#Checksum">
-        <skos:scopeNote xml:lang="en">A value that allows the contents of a file to be authenticated. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented. In [DCAT-AP-v2.0.1], this class is defined as the range for the optional property &apos;&apos;spdx:checksum&apos;&apos; of class Distribution. However, in mobilityDCAT-AP, this property is removed. So, the class and its properties are without function but kept for compatibility reasons.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://spdx.org/rdf/terms#algorithm">
-        <skos:scopeNote xml:lang="en">This property identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://spdx.org/rdf/terms#checksumValue">
-        <skos:scopeNote xml:lang="en">This property provides a lower case hexadecimal encoded digest value produced using a specific algorithm.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
-        <rdfs:label xml:lang="en">licence text</rdfs:label>
-        <rdfs:comment xml:lang="en">This property MAY be used to contain the full text of a Licence Document, as a free text. This MAY be used when there is no standard license that can be linked via property dct:identifier. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Rights Statement</skos:scopeNote>
-        <rdfs:comment xml:lang="en">This property MAY describes in a textual form any additional access, usage or licensing information, besides other information under classes dct:RightsStatement and dct:LicenseDocument. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
-        <vs:term_status>stable</vs:term_status>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Licence Document.</skos:scopeNote>
-        <rdfs:label xml:lang="en">Additional information for access and usage</rdfs:label>
-        <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/LicenseDocument"/>
-        <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/RightsStatement"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/conformsTo">
-        <rdfs:label xml:lang="en">standard name</rdfs:label>
-        <rdfs:comment xml:lang="en">This property describes the name of the mobility data standard. This property is necessary for the following CASE 1: A custom instance of mobilitydcatap:MobilityDataStandard is defined. Such custom instance is recommended when the mobility data standard is detailed out via properties owl:versionInfo and/or mobilitydcatap:schema. The property dct:conformsTo would then name the mobility data standard via a controlled vocabulary. In the alternative CASE 2, the name the mobility data standard is directly named as range of mobilitydcatap:MobilityDataStandard, again via the same controlled vocabulary.</rdfs:comment>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard. </skos:scopeNote>
-        <dcam:domainIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#versionInfo">
-        <rdfs:label xml:lang="en">version</rdfs:label>
-        <rdfs:comment xml:lang="en">This property describes the version of the mobility data standard, as applied within the delivered content. A version might be, e.g., DATEX II v3.2. This information is provided in a textual format. To avoid ambiguity, only short version identifiers SHOULD be used, e.g., only  “3.2”, without redundant acronyms such as “v”, underscores etc.</rdfs:comment>
-        <skos:scopeNote xml:lang="en">This property contains a version number or other version designation of the dataset. The version should be updated, whenever there are changes to the dataset noted by the property dct:modified. Together with property adms:versionNotes, this MAY also enable a change history (or version history) of the corresponding dataset, which could be hosted and published on the data platform. It is recommended to follow W3C Data on the Web Best Practices [DWBP]. Version identifiers should enable comparison of versions and distinguishing major from minor versions, such as Semantic Versioning [SEMVER].</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard. </skos:scopeNote>
-        <dcam:domainIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#Concept">
-        <skos:scopeNote xml:lang="en">A category of a dataset, i.e. a specific subject, theme, or a class about its content. The category is described via a categorisation scheme, i.e. a classification or a taxonomy. Such scheme lists all potential categories, see class &apos;&apos;Category Scheme&apos;&apos;. In mobilityDCAT-AP, this class SHOULD only be used in the context of a data set (via property &apos;&apos;dcat:theme&apos;&apos;). In other contexts, e.g. under [geoDCAT-AP-v2.0.0], this might also be used to describe the theme of a Catalogue or Data Service.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme">
-        <skos:scopeNote xml:lang="en">A categorisation scheme, i.e. a classification or a taxonomy, listing all potential categories which might be used for instances of class Category. In mobilityDCAT-AP, this scheme is expressed via a controlled vocabulary for the property &apos;&apos;dcat:theme&apos;&apos; of class Dataset.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#notation">
-        <skos:scopeNote xml:lang="en">This property contains a string that is an identifier in the context of the identifier scheme referenced by its data type.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Kind">
-        <skos:scopeNote xml:lang="en">A description following the [VCARD-RDF] specification, e.g. to provide telephone number and e-mail address for a contact point. Note that the class vcard:Kind is the parent class for the four explicit types of vCards (vcard:Individual, vcard:Organization, vcard:Location, vcard:Group). This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is only used as the range of the recommended property &apos;&apos;dcat:contactPoint&apos;&apos; for class Dataset. In mobilityDCAT-AP, however, this property is removed, and any contact details are compiled under the Agent class, see § 7. Agent Types, Agent Roles and Agent Properties. Thus, this class SHOULD NOT be used but is kept for compatibility reasons with [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#Catalog">
-        <skos:scopeNote xml:lang="en">A concrete mobility data portal, i.e, a web portal, where mobility-related datasets and their distributions are described via metadata and discoverable for data users.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#CatalogRecord">
-        <skos:scopeNote xml:lang="en">A description of a metadata entry in the mobility data portal, referring to one data set and its distributions published on the portal. mobilityDCAT-AP assumes that metadata records are essential in mobility data portals, so the obligation of this class is raised to “mandatory”, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#DataService">
-        <skos:scopeNote xml:lang="en">A collection of operations that provides access to one or more datasets or data processing functions.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#Dataset">
-        <skos:scopeNote xml:lang="en">A dataset is a collection of data, published or curated by a single source, and available for access or download at the mobility data portal in one or more distributions. In the context of mobility-related data exchange, this might be, e.g., a data collection about static parking information for truck drivers, published by a road authority.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#Distribution">
-        <skos:scopeNote xml:lang="en">A distribution describes the data formats and communication methods for a dataset. There may be one or multiple distributions for one dataset. For example, the same data set (e.g. static parking information for truck drivers) can be provided in different ways e.g. as downloadable zip file or as XML using a SOAP web service. These are two distributions based on one data set. In [DCAT-AP-v2.0.1], this class has been classified as ‘Recommended’, to allow for cases that a particular Dataset does not have a Distribution, i.e. . However, for the context of mobility data portals, it can be expected that all datasets have one or more Distributions. Thus, the obligation of class Distribution is raised to mandatory, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#Relationship">
-        <skos:scopeNote xml:lang="en">An association class for attaching additional information to a relationship between DCAT Resources</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#accessService">
-        <skos:scopeNote xml:lang="en">This property refers to a Data Service that gives access to the Distribution of the Dataset.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#accessURL">
-        <skos:scopeNote xml:lang="en">This property contains a URL that gives access to a Distribution of the Dataset. Depending on the type of data provision, there are different options for describing the URL. For data services, e.g., API, broker services, data feeds, etc., the URL MAY be the end point of such service. However, if some agreements between the data provider and the data user need to be established first, the access URL may link to web page, where the access is further arranged, e.g., initiating a a subscription process. For data which can be downloaded directly, the download URL should be copied from the optional property dcat:downloadURL. For other cases, where data cannot be directly accessed or downloaded via the platform, the access URL MAY be a link to an external service or a website which enables access to the data. This way, this property is the primary key to link to a data service. There is also specific class dcat:DataService, which can be linked via property dcat:accessService. See § 4.9 Data Service for a usage note about the class Data Service.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#bbox">
-        <skos:scopeNote xml:lang="en">This property refers to the geographic bounding box of a resource.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#centroid">
-        <skos:scopeNote xml:lang="en">This property refers to the geographic centre (centroid) of a resource.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#dataset">
-        <skos:scopeNote xml:lang="en">This property links the mobility data portal with a data set that is described at the mobility data portal. This is a direct link from the mobility data portal to a dataset. However, in mobilityDCAT-AP, datasets SHOULD be linked indirectly, i.e., via the metadata record of this dataset. Thus, it is also mandatory to use the property dcat:record.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#endDate">
-        <skos:scopeNote xml:lang="en">This property contains the end of the Period of Time.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#endpointDescription">
-        <skos:scopeNote xml:lang="en">This property contains a description of the Data Services available via the endpoints, including their operations, parameters etc. The property gives specific details of the actual endpoint instances, while dct:conformsTo is used to indicate the general standard or specification that the endpoints implement.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#endpointURL">
-        <skos:scopeNote xml:lang="en">The root location or primary endpoint of the Service (an IRI).</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#hadRole">
-        <skos:scopeNote xml:lang="en">This property refers to the function of an entity or agent with respect to another entity or resource.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#keyword">
-        <skos:scopeNote xml:lang="en">This property contains a keyword or tag describing the Dataset. For the purposes of mobility data portals, it is not recommended to use keywords, as they might be ambiguous, language-dependent and make data search difficult. Instead, usage of mobility-related properties with Controlled Vocabularies is recommended, in particular dcat:theme, mobilitydcatap:networkCoverage and mobilitydcatap:transportMode. If there are relevant keywords that are not part of such Controlled Vocabularies, please contact the authors of &apos;&apos;mobilityDCAT-AP&apos;&apos;, in order to update the Controlled Vocabularies.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#packageFormat">
-        <skos:scopeNote xml:lang="en">In GeoDCAT-AP, this property is used as in DCAT and DCAT-AP.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#qualifiedRelation">
-        <skos:scopeNote xml:lang="en">In GeoDCAT-AP, this property is used as in DCAT and DCAT-AP.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#record">
-        <skos:scopeNote xml:lang="en">This property refers to a metadata record that is part of the mobility data portal. mobilityDCAT-AP assumes that metadata records are essential in mobility data portals, so the obligation of this property is raised to “mandatory”, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#servesDataset">
-        <skos:scopeNote xml:lang="en">This property refers to a Dataset that this Data Service can distribute.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#startDate">
-        <skos:scopeNote xml:lang="en">This property contains the start of the Period of Time.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#temporalResolution">
-        <skos:scopeNote xml:lang="en">In GeoDCAT-AP, this property is used as in DCAT and DCAT-AP.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/dcat#themeTaxonomy">
-        <skos:scopeNote xml:lang="en">The value to be used for this property is the URI of the vocabulary itself, i.e. the concept scheme, not the URIs of the concepts in the vocabulary.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/locn#geometry">
-        <skos:scopeNote xml:lang="en">This property associates any resource with the corresponding geometry.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/oa#hasBody">
-        <rdfs:comment xml:lang="en">This property MAY be used to describe the result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes.</rdfs:comment>
-        <rdfs:comment xml:lang="en">This property MAY be used to describe any quality aspects regarding the delivered content, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes.</rdfs:comment>
-        <rdfs:label xml:lang="en">quality annotation resource</rdfs:label>
-        <rdfs:label xml:lang="en">assessment result</rdfs:label>
-        <dcam:domainIncludes rdf:resource="http://w3id.org/mobilitydcat-ap#Assessment"/>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Assessment. </skos:scopeNote>
-        <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dqv#QualityAnnotation"/>
-        <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
-        <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Quality Annotation. </skos:scopeNote>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
-        <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/Agent">
-        <skos:scopeNote xml:lang="en">An entity (e.g., an individual or an organisation) that is associated with Catalogues, Catalogue Records, or Datasets. If the Agent is an organisation, the use of the Organization Ontology [VOCAB-ORG] is recommended. See § 7. Agent Types, Agent Roles and Agent Properties for a discussion on Agent types, roles and properties. The &apos;&apos;foaf:mbox&apos;&apos; mandatory property is not included in [DCAT-AP-v2.0.1]. The &apos;&apos;foaf:workplaceHomepage&apos;&apos; recommended property is not included in [DCAT-AP-v2.0.1], The &apos;&apos;locn:address&apos;&apos;, &apos;&apos;org:memberOf&apos;&apos;, &apos;&apos;foaf:firstName&apos;&apos;, &apos;&apos;foaf:phone&apos;&apos;, &apos;&apos;foaf:surname&apos;&apos; optional properties are not included in [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/Document">
-        <skos:scopeNote xml:lang="en">A textual resource intended for human consumption that contains information, e.g., a Web page about a Dataset.  This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is only used as the range of the recommended properties &apos;&apos;foaf:homepage&apos;&apos; for class Catalogue; the optional properties &apos;&apos;foaf:page&apos;&apos; and &apos;&apos;dcat:landingPage&apos;&apos; for class Dataset; and the optional property &apos;&apos;foaf:page&apos;&apos; for class Distribution. In mobilityDCAT-AP, however, the range of &apos;&apos;foaf:homepage&apos;&apos; for class Catalogue is changed to the more generic range &apos;&apos;rdfs:Resource&apos;&apos;. The other, above-mentioned properties are removed. Thus, this class SHOULD NOT be used, but is kept for compatibility reasons with [DCAT-AP-v2.0.1]</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/homepage">
-        <skos:scopeNote xml:lang="en">This property refers to a Web page that acts as the main page for the mobility data portal. The obligation of this property is raised to “mandatory”, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/primaryTopic">
-        <skos:scopeNote xml:lang="en">This property links the metadata entry to the dataset described in the entry.</skos:scopeNote>
-    </rdf:Description>
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:adms="http://www.w3.org/ns/adms#"
+   xmlns:bibo="http://purl.org/ontology/bibo/"
+   xmlns:dcam="http://purl.org/dc/dcam/"
+   xmlns:dcat="http://www.w3.org/ns/dcat#"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:foaf="http://xmlns.com/foaf/0.1/"
+   xmlns:owl="http://www.w3.org/2002/07/owl#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:vann="http://purl.org/vocab/vann/"
+   xmlns:voaf="http://purl.org/vocommons/voaf#"
+   xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap/">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <dct:conformsTo rdf:resource="http://data.europa.eu/r5r/"/>
+    <dct:conformsTo rdf:resource="https://eur-lex.europa.eu/eli/reg/2008/1205/2008-12-24"/>
+    <dct:conformsTo rdf:resource="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements"/>
+    <dct:conformsTo rdf:resource="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/document/change-and-release-management-policy-dcat-ap"/>
+    <dct:conformsTo rdf:resource="https://www.w3.org/TR/vocab-dcat-2/"/>
+    <dct:publisher rdf:resource="http://publications.europa.eu/resource/authority/corporate-body/COM"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b6">
+    <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
+    <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/HTML"/>
+    <dct:title xml:lang="en">HTML</dct:title>
+    <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/HumanLanguage"/>
+    <dcat:downloadURL rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.1.0/"/>
+    <dcat:mediaType rdf:datatype="http://purl.org/dc/terms/IMT">text/html</dcat:mediaType>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/contributor">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#hasTelephone">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to provide the phone number of the Kind, specified using fully qualified tel: URI scheme [RFC3966]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
+    <rdfs:label xml:lang="en">phone</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dqv#hasQualityAnnotation">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY describe any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Rights Holder (see property dct:rightsHolder). This information SHOULD assist data consumers in determining the value of data, before actually accessing and processing it. Thus, the information SHOULD be publicly available. Furthermore, it can be helpful for validation processes by 3rd parties, e.g., a National Body in context of EU Delegated Regulations. Quality aspects SHOULD be noted via a free text and/or via URLs linking to further quality information. If there is absolutely no quality information, at least a note “quality information is unknown” SHOULD be given. If existing quality frameworks have been applied in the quality assessment, e.g., the Quality Packages from the EU EIP and NAPCORE projects [EU-EIP-QP], these frameworks should be referenced.  </rdfs:comment>
+    <rdfs:label xml:lang="en">quality description</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/dqv#QualityAnnotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dqv#QualityAnnotation">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An annotation about any quality aspects regarding the delivered content, in particular methods, metrics/indicators and results of a quality assessment in the responsibility of the Data Owner. There is a similar class  “Quality Measurement” in [GEODCAT-AP-v2.0.0]. Both  “Quality Annotation” are  “Quality Measurement” are reusing the Data Quality Vocabulary [VOCAB-DQV]. Quality Measurement is referring to concrete metrics, like sub-types of spatial resolutions being used [GEODCAT-AP-v2.0.0]. At mobility data portals, however, the practice so far is to provide some free text about quality aspects. Thus, the Quality Annotation refers to an unspecified form of quality annotation, which MAY be a free text. </rdfs:comment>
+    <rdfs:label xml:lang="en">Quality Annotation</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.w3.org/ns/oa#hasBody">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to describe the result of the latest assessment procedure in form of a URL, or any quality aspects regarding the delivered content. Textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model.</rdfs:comment>
+    <rdfs:label xml:lang="en">annotation body</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property for Assessment and Quality Annotation.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="https://w3id.org/mobilitydcat-ap#Assessment"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dqv#QualityAnnotation"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#">
+    <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+    <rdf:type rdf:resource="http://www.w3.org/ns/adms#Asset"/>
+    <rdfs:label xml:lang="en">mobilityDCAT-AP</rdfs:label>
+    <dct:abstract xml:lang="en">mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. </dct:abstract>
+    <dct:alternative xml:lang="en">mobilityDCAT-AP - Version 1.1.0: A mobility extension for the DCAT application profile for data portals in Europe</dct:alternative>
+    <skos:altLabel xml:lang="en">mobilityDCAT-AP - Version 1.1.0: A mobility extension for the DCAT application profile for data portals in Europe</skos:altLabel>
+    <dct:conformsTo rdf:resource="http://data.europa.eu/r5r/"/>
+    <dct:conformsTo rdf:resource="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements"/>
+    <dct:conformsTo rdf:resource="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/document/change-and-release-management-policy-dcat-ap"/>
+    <dct:conformsTo rdf:resource="https://www.w3.org/TR/vocab-dcat-2/"/>
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-05-11</dct:created>
+    <dct:creator rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b1"/>
+    <dct:dateCopyrighted rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">2023</dct:dateCopyrighted>
+    <dct:description xml:lang="en">mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. </dct:description>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-01-17</dct:issued>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-01-17</dct:modified>
+    <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <dct:publisher rdf:resource="https://napcore.eu/"/>
+    <dct:rightsHolder rdf:resource="https://napcore.eu/"/>
+    <dct:title xml:lang="en">mobilityDCAT-AP</dct:title>
+    <dct:type rdf:resource="http://publications.europa.eu/resource/authority/asset-classification/c_89b4bdb7"/>
+    <dct:type rdf:resource="http://publications.europa.eu/resource/authority/dataset-type/APROF"/>
+    <dct:type rdf:resource="http://publications.europa.eu/resource/authority/dataset-type/ONTOLOGY"/>
+    <bibo:editor rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b2"/>
+    <bibo:editor rdf:resource="https://lina-molinas-comet.name/foaf/#me"/>
+    <vann:preferredNamespacePrefix>mobilitydcatap</vann:preferredNamespacePrefix>
+    <vann:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://w3id.org/mobilitydcat-ap#</vann:preferredNamespaceUri>
+    <voaf:reliesOn rdf:resource="http://data.europa.eu/r5r/"/>
+    <voaf:reliesOn rdf:resource="http://purl.org/dc/terms/"/>
+    <voaf:reliesOn rdf:resource="http://spdx.org/rdf/terms#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/2000/01/rdf-schema#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/2002/07/owl#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/2004/02/skos/core#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/2006/vcard/ns#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/2011/content#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/ns/adms#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/ns/dcat#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/ns/dqv#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/ns/locn#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/ns/org#"/>
+    <voaf:reliesOn rdf:resource="http://www.w3.org/ns/prov#"/>
+    <voaf:reliesOn rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:comment xml:lang="en">mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. </rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.1.0/"/>
+    <owl:backwardCompatibleWith rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.0.1/"/>
+    <owl:priorVersion rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.0.1/"/>
+    <owl:versionIRI rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.1.0/"/>
+    <owl:versionInfo xml:lang="en">Version 1.1.0</owl:versionInfo>
+    <adms:last rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.1.0/"/>
+    <adms:prev rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.0.1/"/>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/dataset-status/COMPLETED"/>
+    <adms:versionNotes xml:lang="en">mobilityDCAT-AP 1.1.0 extends mobilityDCAT-AP 1.0.1. Key changes: added dct:source property for Catalogue Record (harvesting use cases); changed cardinality of mobilitydcatap:schema from 0..1 to 0..n; added dct:conformsTo optional property for Mobility Data Standard. Errata corrections and UML diagram updates included.</adms:versionNotes>
+    <dcat:distribution rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b3"/>
+    <dcat:distribution rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b4"/>
+    <dcat:distribution rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b5"/>
+    <dcat:distribution rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b6"/>
+    <foaf:depiction rdf:resource="https://mobilitydcat-ap.github.io/mobilityDCAT-AP/drafts/1.1.0-draft-0.1/figures/mobilityDCAT-AP_uml-diagramm_240816.png"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#communicationMethod">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property indicates for data services, e.g., data feeds, if the data interface of the data provider system functions in a push or pull mode. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.</rdfs:comment>
+    <rdfs:label xml:lang="en">communication method</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/identifier">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/LicenseDocument"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Catalog"/>
+    <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/Location"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#assessmentResult">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY refer to the results and outcomes from an assessment process by some organisation, e.g., a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance of the Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies [NAPCORE-NB] and installed individually in each Member State. The property MAY point to the most recent assessment procedure, including its date, its result as a free-text and/or a link referring to an assessment report online. The difference to the property dqv:hasQualityAnnotation is that the latter one is provided by the data provider, while the assessment results are provided by an external organisation. </rdfs:comment>
+    <rdfs:label xml:lang="en">assessment result</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="https://w3id.org/mobilitydcat-ap#Assessment"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#organization-name">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to specify the affiliation of the Kind. This property can be repeated for different versions of the name (e.g. the name in different languages) - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
+    <rdfs:label xml:lang="en">affiliation</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#DataService">
+    <skos:scopeNote xml:lang="en">A collection of operations that provides access to one or more datasets or data processing functions.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#georeferencingMethod">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property SHOULD be used to specify the georeferencing method used in the dataset. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided, denoting commonly used georeferencing methods for mobility data.</rdfs:comment>
+    <rdfs:label xml:lang="en">georeferencing method</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#mobilityDataStandard">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/format"/>
+    <rdfs:comment xml:lang="en">This property describes the mobility data standard, as applied for the delivered content within the Distribution. A mobility data standard, e.g., DATEX II, combines syntax and semantic definitions of entities in a certain domain (e.g., for DATEX II: road traffic information), and optionally adds technical rules for data exchange. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided, listing common mobility data standards. If no established mobility data standard is applied, an information “proprietary standard” is requested. </rdfs:comment>
+    <rdfs:label xml:lang="en">mobility data standard</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Distributions.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
+    <dcam:rangeIncludes rdf:resource="https://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property contains a preferred label of the Location. This property can be repeated for parallel language versions of the label - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">geographic name</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Location.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">This property contains a preferred label of the Category. This property can be repeated for parallel language versions of the label - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/Location"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#packageFormat">
+    <skos:scopeNote xml:lang="en">In GeoDCAT-AP, this property is used as in DCAT and DCAT-AP.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#mobilityTheme">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/dcat#theme"/>
+    <rdfs:comment xml:lang="en">This property refers to the mobility-related theme (i.e., a specific subject, category, or type) of the delivered content. A dataset may be associated with multiple themes. A theme is important for data seekers who are interested in a particular type of data content. The theme is described via a controlled vocabulary in two hierarchy levels: The 1st level is a mandatory field labelled “Data content category, describing the classification of the data content on an aggregated level. The 2nd level is an optional field labelled “Data content sub category”, detailing the “Data content category” via one or several sub-categories. When entering the metadata for one dataset, the data provider would first select one or several options of a “Data content category”, and then optionally details this with one or more options of corresponding “Data content sub category”. The platform must be able to handle the dependencies between these two levels, i.e., match the allowed options between the 1st and 2nd level. The corresponding controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. This property is a sub-property of dcat:theme, which is also a further, recommended property of Dataset. To distinguish the both theme properties, it is recommended to label mobilitydcatap:mobilityTheme as “Mobility Theme”, and dcat:theme as “EU Open Data Theme”. The subject of a dataset MAY also be described via a property dcat:keyword. However, the usage of “theme / category” is preferred, to avoid ambiguity and uncontrolled theme descriptions.</rdfs:comment>
+    <rdfs:label xml:lang="en">mobility theme</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for  Dataset.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.w3.org/ns/oa#hasTarget">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to describe the target of the quality annotation, referring back to the dataset being described. I.e., it is the inverse property of “dqv:hasQualityAnnotation” for class Dataset.</rdfs:comment>
+    <rdfs:label xml:lang="en">quality annotation target</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Quality Annotation. </skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dqv#QualityAnnotation"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#applicationLayerProtocol">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property describes the transmitting channel, i.e., the Application Layer Protocol, of the distribution. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. </rdfs:comment>
+    <rdfs:label xml:lang="en">application layer protocol</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this property is recommended to be used for Distributions.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/adms#sample">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property refers to a sample Distribution of the Dataset. A data sample allows data users to investigate the data content and data structure, without subscribing to a data feed or downloading a complete data set. In [DCAT-AP-v2.0.1], there is a property adms:sample under the class dcat:Dataset , with a range of dcat:Distribution. This implies, that all mandatory properties from dcat:Distribution, e.g., mobilitydcatap:mobilityDataStandard, must be applied. To simplify the description of the Sample, mobilityDCAT-AP recommends to describe the Sample via a property under class dcat:Distribution. It is assumed that all other properties, as already populated for dcat:Distribution, e.g., mobilitydcatap:mobilityDataStandard, also apply for the description of the data sample.  </rdfs:comment>
+    <rdfs:label xml:lang="en">sample</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/description">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <skos:scopeNote xml:lang="en">This property contains a free-text, individual name of the mobility data platform itself. This property MAY be repeated for parallel language versions of the description - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/phone">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to provide the phone number of the Agent, specified using fully qualified tel: URI scheme [RFC3966]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">phone</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#downloadURL">
+    <skos:scopeNote xml:lang="en">This property contains a URL that is a direct link to a downloadable file in a given format.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/rightsHolder">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property refers to an entity that legally owns or holds the rights of the data provided in a dataset. This entity is legally responsible for the content of the data. It is also responsible for any statements about the data quality (if applicable, see property dqv:hasQualityAnnotation) and/or the relevance to legal frameworks (if applicable, see property dcatap:applicableLegislation). This entity is the direct contact for the platform operator or data consumers, who have questions or issues about the contents of a dataset. The Rights Holder will be in many cases identical with the Publisher information for class Dataset (see property dct:publisher) and/or for class Catalogue Record (see property dct:publisher). In this case, the contact data MAY be copied from the corresponding Publisher entries. There might be also cases with non-identical entities: e.g., when one or several Rights Holders contract a third-party Publisher (e.g., an IT service company), which is producing, hosting and publishing a dataset. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">rights holder</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Dataset. </skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/issued">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to describe the date of the latest assessment procedure.</rdfs:comment>
+    <rdfs:label xml:lang="en">assessment date</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Assessment. Its range is rdfs:Literal typed as xsd:date or xsd:dateTime. </skos:scopeNote>
+    <skos:scopeNote xml:lang="en">This property contains the date of formal issuance (e.g., publication) of the Catalogue.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="https://w3id.org/mobilitydcat-ap#Assessment"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#record">
+    <skos:scopeNote xml:lang="en">This property refers to a metadata record that is part of the mobility data portal. mobilityDCAT-AP assumes that metadata records are essential in mobility data portals, so the obligation of this property is raised to “mandatory”, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#grammar">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/conformsTo"/>
+    <rdfs:comment xml:lang="en">This property describes the technical data grammar format of the delivered content within the Distribution. It describes the standard on top of the elementary syntax that describe data structures in the dataset. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. This is a sub-property of dct:conformsTo.</rdfs:comment>
+    <rdfs:label xml:lang="en">grammar</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#address">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to specify the postal address of the Agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">address</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b5">
+    <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
+    <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/RDF_XML"/>
+    <dct:format rdf:resource="http://www.w3.org/ns/formats/data/RDF_XML"/>
+    <dct:title xml:lang="en">RDF/XML</dct:title>
+    <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
+    <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
+    <dcat:downloadURL rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.1.0/mobilitydcat-ap.rdf"/>
+    <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/application/rdf+xml"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#hasEmail">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property contains an email address of the Kind, specified using fully qualified mailto: URI scheme [RFC6068]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].  </rdfs:comment>
+    <rdfs:label xml:lang="en">email</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/source">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property is used for metadata records that are harvested from other portals. Harvesting, i.e., the automated import of metadata information from external portals, seems to be a common case for some NAPs. With these property, a data user can see, if the metadata was harvested, and from where. The property SHOULD link to a public URL of the dataset descripton on the original data portal, from where the metadata was harvested.</rdfs:comment>
+    <rdfs:label xml:lang="en">source metadata</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Catalogue Record.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b3">
+    <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
+    <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/JSON_LD"/>
+    <dct:format rdf:resource="http://www.w3.org/ns/formats/data/JSON-LD"/>
+    <dct:title xml:lang="en">JSON-LD</dct:title>
+    <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
+    <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
+    <dcat:downloadURL rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.1.0/mobilitydcat-ap.jsonld"/>
+    <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/application/ld+json"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#hasURL">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property points to a Web site of the Kind. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].  </rdfs:comment>
+    <rdfs:label xml:lang="en">URL</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#fn">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property contains a name of the Kind. This property can be repeated for different versions of the name (e.g., the name in different languages) - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
+    <rdfs:label xml:lang="en">name</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Kind.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to contain the full text of a Licence Document as a free text, or to describe additional access, usage or licensing information for a Rights Statement. This property can be repeated for parallel language versions. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">licence text / additional access information</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property for Licence Document and a recommended property for Rights Statement.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/LicenseDocument"/>
+    <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/RightsStatement"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#intendedInformationService">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY describe predefined information services, which the data content is intended to support. Such services MAY be, e.g., information services for multimodal mobility, as specified by EC Delegated Regulation 2017/1926 [EC-MMTIS-DR]. Examples of such services include “location search”, which is based on a datasets with address identifiers, or “trip plan computation”, which is based on datasets about a road network. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.</rdfs:comment>
+    <rdfs:label xml:lang="en">intended information service</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#adminUnitL2">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The administrative area of an Address of the Agent. Depending on the country, this corresponds to a province, a county, a region, or a state.</rdfs:comment>
+    <rdfs:label xml:lang="en">administrative area</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/publisher">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property refers to an entity (an organisation or a person), which is responsible for creation and maintenance of the metadata entry on the data platform. This entity is the direct contact for the data platform operators or data-searching users, who have questions or issues about the metadata entry. This information can be natively created by a data platform, then corresponding to the entity that is registered to the data platform and has the role of a metadata creator. This information can be also harvested from other portals. It should include, as a minimum, the name and email address of the entity. The information might be identical to the property “Publisher” of the corresponding dataset. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. </rdfs:comment>
+    <rdfs:label xml:lang="en">publisher</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Catalogue Record.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
+    <dcam:rangeIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#transportMode">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property describes the transport mode that is covered by the delivered content. Data can be valid for more than one mode, so a multiple choice should be applied. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided, denoting commonly used transport modes.</rdfs:comment>
+    <rdfs:label xml:lang="en">transportation mode</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/RightsStatement">
+    <skos:scopeNote xml:lang="en">A statement about the intellectual property rights (IPR) held in or over a resource, a legal document giving official permission to do something with a resource, or a statement about access rights. As a minimum, it should include an information on the type of conditions for access and usage. Information about concrete licenses can be provided via class License Document. The ''dct:type'' mandatory property is not included in [DCAT-AP-v2.0.1]. The ''rdfs:label'' recommended property is not included in [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/license">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <skos:scopeNote xml:lang="en">This property contains the licence under which the Data Service is made available.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/adms#identifier">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used as an additional identifier, besides dct:identifier. It MAY be referring to a dedicated, EU-wide identificator system of NAPS or other portals, to be introduced in the future.</rdfs:comment>
+    <rdfs:label xml:lang="en">other identifier</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Catalogue. </skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Catalog"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/adms#Identifier"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#hasAddress">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to specify the postal address of the Kind. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].  </rdfs:comment>
+    <rdfs:label xml:lang="en">address</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Kind.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#temporalResolution">
+    <skos:scopeNote xml:lang="en">In GeoDCAT-AP, this property is used as in DCAT and DCAT-AP.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#endpointDescription">
+    <skos:scopeNote xml:lang="en">This property contains a description of the Data Services available via the endpoints, including their operations, parameters etc. The property gives specific details of the actual endpoint instances, while dct:conformsTo is used to indicate the general standard or specification that the endpoints implement.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://data.europa.eu/r5r/applicableLegislation">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY refer to one or several legal frameworks being relevant for the dataset, e.g., an EC Delegated Regulation which constitutes the purpose of the corresponding data platform (here called National Access Point/NAP), or some other international or national frameworks, e.g., Open Data regulations. For European legal frameworks, it is recommended to use the European Legislation Identifier [ELI] to refer to legislation whenever possible. This property is derived from the DCAT-AP HVD extension [DCAT-AP-HVD].</rdfs:comment>
+    <rdfs:label xml:lang="en">applicable legislation</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Datasets.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/depiction">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#inScheme">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to specify the Category Scheme to which the Category belongs, or the gazetteer to which the Location belongs. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">category scheme / gazetteer</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property for Category and a recommended property for Location.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/Location"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#schema">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/conformsTo"/>
+    <rdfs:comment xml:lang="en">This property describes the schema of the mobility data standard, as applied within the delivered content. There are differet optiions how to reference the schema. It might be a reference to a portal-internal catalogue of schemas, a reference to an individual schema (that is provided by the data publisher), or a reference to an external catalogue of schemas (like a stakeholder-based DATEX II profile published on the datex2.eu page). The data platform SHOULD keep an archive of commonly used schemas. The data provider SHOULD be able to select an applicable schema from this archive, or to upload an own, individual schema. In any case, the schema should be available as a resource. This is a sub-property of dct:conformsTo.</rdfs:comment>
+    <rdfs:label xml:lang="en">schema</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="https://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/created">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property contains the date stamp (date and time) when the metadata entry was created for the first time. It SHOULD be generated by the system, whenever a platform user enters the metadata entry. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">creation date</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Catalogue Record. Its range is rdfs:Literal typed as xsd:date or xsd:dateTime. </skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b1">
+    <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Group"/>
+    <foaf:name>NAPCORE SWG 4.4</foaf:name>
+    <foaf:page rdf:resource="https://github.com/mobilityDCAT-AP/mobilityDCAT-AP"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/name">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <skos:scopeNote xml:lang="en">This property contains a name of the Agent. This property can be repeated for different versions of the name (e.g. the name in different languages) - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/mbox">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">email</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Agent</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#adminUnitL1">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The country of an Address of the Agent.</rdfs:comment>
+    <rdfs:label xml:lang="en">country</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/language">
+    <skos:scopeNote xml:lang="en">This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the metadata entry. The value should be generated automatically by the NAP system, corresponding to the currently used language in the user interface. Some portals offer multilingual user interfaces, e.g., in the local language and additionally in English. For multiple languages - see § 8. Accessibility and Multilingual Aspects. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/conformsTo">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">reference system / standard name</rdfs:label>
+    <rdfs:comment xml:lang="en">Used as reference system for Dataset (range dct:Standard) and as standard name for MobilityDataStandard (range skos:Concept).</rdfs:comment>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property for Dataset and an optional property for Mobility Data Standard.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:domainIncludes rdf:resource="https://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
+    <dcam:rangeIncludes rdf:resource="http://purl.org/dc/terms/Standard"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://spdx.org/rdf/terms#Checksum">
+    <skos:scopeNote xml:lang="en">A value that allows the contents of a file to be authenticated. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented. In [DCAT-AP-v2.0.1], this class is defined as the range for the optional property ''spdx:checksum'' of class Distribution. However, in mobilityDCAT-AP, this property is removed. So, the class and its properties are without function but kept for compatibility reasons.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#Address">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">A postal address of the Agent.A postal address of the Agent. </rdfs:comment>
+    <rdfs:label xml:lang="en">Address (Agent)</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/relation">
+    <skos:scopeNote xml:lang="en">This property references, cites, or otherwise points to another, related dataset. Corresponds to the property dct:isReferencedBy, with contrary relationship. It may be a link between two individual datasets that complement each other, e.g. one dataset with static parking data, and one with dynamic parking data, both covering the same parking facilities.	</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2011/content#characterEncoding">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property describes the technical encoding format of the delivered content within the Distribution. It SHOULD be expressed using a character set name defined in the IANA register [IANA-CHARSETS]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. This is a sub-property of dct:conformsTo.</rdfs:comment>
+    <rdfs:label xml:lang="en">character encoding</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#postName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The city of an Address of the Agent.</rdfs:comment>
+    <rdfs:label xml:lang="en">city</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b4">
+    <rdf:type rdf:resource="http://www.w3.org/ns/adms#AssetDistribution"/>
+    <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE"/>
+    <dct:format rdf:resource="http://www.w3.org/ns/formats/data/Turtle"/>
+    <dct:title xml:lang="en">Turtle</dct:title>
+    <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/OWL"/>
+    <adms:representationTechnique rdf:resource="http://purl.org/adms/representationtechnique/RDFSchema"/>
+    <dcat:downloadURL rdf:resource="https://w3id.org/mobilitydcat-ap/releases/1.1.0/mobilitydcat-ap.ttl"/>
+    <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/text/turtle"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://data.europa.eu/r5r/">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#Assessment">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An assessment procedure by an external organisation. This organisation MAY be a National Body in the context of EU Delegated Regulations. EU Delegated Regulations require Member States to set up procedures to assess the compliance with the applicable Delegated Regulations, e.g. regarding the provisioning of data via a NAP. These assessment processes are handled by National Bodies [NAPCORE-NB] and installed individually in each Member State. The information is optional and needed for the documentation of the assessment procedure. It MAY be an internal information, only visible for assessment organisations or other authorised users.  </rdfs:comment>
+    <rdfs:label xml:lang="en">Assessment</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional class.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#thoroughfare">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The street name and civic number of an Address of the Agent.</rdfs:comment>
+    <rdfs:label xml:lang="en">street address</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#accessService">
+    <skos:scopeNote xml:lang="en">This property refers to a Data Service that gives access to the Distribution of the Dataset.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#MobilityDataStandard">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:subClassOf rdf:resource="http://purl.org/dc/terms/Standard"/>
+    <rdfs:comment xml:lang="en">The mobility data standard applied for the delivered content. A mobility data standard, e.g., DATEX II, combines syntax and semantic definitions of entities in a certain domain (e.g., for DATEX II: road traffic information), and optionally adds technical rules for data exchange. This is a sub-class of dct:Standard.</rdfs:comment>
+    <rdfs:label xml:lang="en">Mobility Data Standard</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory class.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/org#memberOf">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the affiliation of the Agent, see § 7. Agent Types, Agent Roles and Contact Information. This property is analogue to an addition by [GEODCAT-AP-v2.0.0].</rdfs:comment>
+    <rdfs:label xml:lang="en">affiliation</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/org#Organization"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/surname">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the surname of the Agent, see section 7.</rdfs:comment>
+    <rdfs:label xml:lang="en">surname</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#themeTaxonomy">
+    <skos:scopeNote xml:lang="en">The value to be used for this property is the URI of the vocabulary itself, i.e. the concept scheme, not the URIs of the concepts in the vocabulary.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#notation">
+    <skos:scopeNote xml:lang="en">This property contains a string that is an identifier in the context of the identifier scheme referenced by its data type.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#versionInfo">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property describes the version of the mobility data standard, as applied within the delivered content. A version might be, e.g., DATEX II v3.2. This information is provided in a textual format. To avoid ambiguity, only short version identifiers SHOULD be used, e.g., only  “3.2”, without redundant acronyms such as “v”, underscores etc.</rdfs:comment>
+    <rdfs:label xml:lang="en">version</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard. </skos:scopeNote>
+    <skos:scopeNote xml:lang="en">This property contains a version number or other version designation of the dataset. The version should be updated, whenever there are changes to the dataset noted by the property dct:modified. Together with property adms:versionNotes, this MAY also enable a change history (or version history) of the corresponding dataset, which could be hosted and published on the data platform. It is recommended to follow W3C Data on the Web Best Practices [DWBP]. Version identifiers should enable comparison of versions and distinguishing major from minor versions, such as Semantic Versioning [SEMVER].</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="https://w3id.org/mobilitydcat-ap#MobilityDataStandard"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#startDate">
+    <skos:scopeNote xml:lang="en">This property contains the start of the Period of Time.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#backwardCompatibleWith">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/temporal">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property describes the beginning and end of the time interval when a data service, e.g., a data feed, is delivered technically via the data platform. If there is no entry it means that the publication gets valid immediately and the timestamp is the same as the metadata timestamp.  </rdfs:comment>
+    <rdfs:label xml:lang="en">temporal coverage</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">This property refers to a temporal period, i.e., the beginning and the end, of the time reference of the delivered content (e.g., validity time of a public-transport time table).</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
+    <dcam:rangeIncludes rdf:resource="http://purl.org/dc/terms/PeriodOfTime"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://eur-lex.europa.eu/eli/reg/2008/1205/2008-12-24">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#altLabel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#hadRole">
+    <skos:scopeNote xml:lang="en">This property refers to the function of an entity or agent with respect to another entity or resource.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme">
+    <skos:scopeNote xml:lang="en">A categorisation scheme, i.e. a classification or a taxonomy, listing all potential categories which might be used for instances of class Category. In mobilityDCAT-AP, this scheme is expressed via a controlled vocabulary for the property ''dcat:theme'' of class Dataset.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/isVersionOf">
+    <skos:scopeNote xml:lang="en">This property refers to a related dataset of which the described dataset is a version, edition, or adaptation. Corresponds to property dct:hasVersion with contrary relationship. It might be used to host multiple versions of the same data set in the data portal, also enabling a version history. Multiple versions should be differentiated via the properties owl:versionInfo and adms:versionNotes.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/firstName">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">If the agent is of type person, this property SHOULD be used to specify the first name of the Agent, see section § 7. Agent Types, Agent Roles and Contact Information.</rdfs:comment>
+    <rdfs:label xml:lang="en">first name</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Agent</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/modified">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <skos:scopeNote xml:lang="en">This property contains the most recent date on which the content of a dataset was changed or modified. This is redundant for high-frequency data services, e.g., via a data feed service, where the change date can be derived from the time stamp within the data feed.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://spdx.org/rdf/terms#algorithm">
+    <skos:scopeNote xml:lang="en">This property identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/vocab/vann/preferredNamespaceUri">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/homepage">
+    <skos:scopeNote xml:lang="en">This property refers to a Web page that acts as the main page for the mobility data portal. The obligation of this property is raised to “mandatory”, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#dataFormatNotes">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">This property contains any additional information about the format of the delivered content within the Distribution (see the corresponding properties dct:format, mobilitydcatap:mobilityDataStandard, mobilitydcatap:grammar), in a textual format. This might be about, e.g., extensions being used in a mobilitydcatap:mobilityDataStandard. </rdfs:comment>
+    <rdfs:label xml:lang="en">data format notes</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is an optional property to be used for Distributions.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/MediaType">
+    <skos:scopeNote xml:lang="en"> A media type, e.g. the format of a computer file. This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is only used as the range of the optional properties ''dcat:compressFormat'', ''dcat:mediaType'', and ''dcat:packageFormat'' for class Distribution. In mobilityDCAT-AP, however, these properties are removed. Thus, this class SHOULD NOT be used but is kept for compatibility reasons with [DCAT-AP-v2.0.1]</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://publications.europa.eu/resource/authority/corporate-body/COM">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/workplaceHomepage">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property MAY be used to specify the Web site of the Agent.</rdfs:comment>
+    <rdfs:label xml:lang="en">URL</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Agent</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://w3id.org/mobilitydcat-ap#networkCoverage">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property describes the part of the transport network that is covered by the delivered content. For road traffic, the property SHOULD refer to the network classification for which the data is provided. As a minimum, an international or higher-level classification, e.g., via functional road classes, is recommended to allow data search across different countries. In addition, national classifications are allowed. For other transport modes, the property is meant to refer to the physical infrastructure which is used by the services covered by the data. For all modes, the property SHOULD also indicate if the data content relates to the EU’s trans-European transport network [EU-TEN-T]. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided, denoting commonly used road and infrastructure network classes.</rdfs:comment>
+    <rdfs:label xml:lang="en">network coverage</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/mobilitydcat-ap#"/>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Datasets.</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#postCode">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The postal code of an Address of the Agent.</rdfs:comment>
+    <rdfs:label xml:lang="en">postal code</rdfs:label>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#CatalogRecord">
+    <skos:scopeNote xml:lang="en">A description of a metadata entry in the mobility data portal, referring to one data set and its distributions published on the portal. mobilityDCAT-AP assumes that metadata records are essential in mobility data portals, so the obligation of this class is raised to “mandatory”, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/type">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">This property SHOULD be used to indicate the conditions if any contracts, licences and/or are applied for the use of the dataset. The conditions are declared on an aggregated level: whether a free and unrestricted use is possible, a contract has to be concluded and/or a licence has to be agreed on to use a dataset. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. The values can be logically mapped with the property dct:identifier from class dct:LicenseDocument. </rdfs:comment>
+    <rdfs:label xml:lang="en">conditions for access and usage</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a mandatory property to be used for Rights Statement.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">This property refers to a type of the Agent that makes the Catalogue, Catalogue Record, Data Service, or Dataset available</skos:scopeNote>
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/concept-status/CURRENT"/>
+    <dcam:domainIncludes rdf:resource="http://purl.org/dc/terms/RightsStatement"/>
+    <dcam:rangeIncludes rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://github.com/lcomet">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <foaf:name>Lina Molinas Comet</foaf:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/primaryTopic">
+    <skos:scopeNote xml:lang="en">This property links the metadata entry to the dataset described in the entry.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://spdx.org/rdf/terms#checksumValue">
+    <skos:scopeNote xml:lang="en">This property provides a lower case hexadecimal encoded digest value produced using a specific algorithm.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#geometry">
+    <skos:scopeNote xml:lang="en">This property associates any resource with the corresponding geometry.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#keyword">
+    <skos:scopeNote xml:lang="en">This property contains a keyword or tag describing the Dataset. For the purposes of mobility data portals, it is not recommended to use keywords, as they might be ambiguous, language-dependent and make data search difficult. Instead, usage of mobility-related properties with Controlled Vocabularies is recommended, in particular dcat:theme, mobilitydcatap:networkCoverage and mobilitydcatap:transportMode. If there are relevant keywords that are not part of such Controlled Vocabularies, please contact the authors of ''mobilityDCAT-AP'', in order to update the Controlled Vocabularies.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#dataset">
+    <skos:scopeNote xml:lang="en">This property links the mobility data portal with a data set that is described at the mobility data portal. This is a direct link from the mobility data portal to a dataset. However, in mobilityDCAT-AP, datasets SHOULD be linked indirectly, i.e., via the metadata record of this dataset. Thus, it is also mandatory to use the property dcat:record.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="n871c35bbf93c44b396b25f5c9dd8d396b2">
+    <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <foaf:name>Lina Molinas Comet</foaf:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#component">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#qualifiedRelation">
+    <skos:scopeNote xml:lang="en">In GeoDCAT-AP, this property is used as in DCAT and DCAT-AP.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/document/change-and-release-management-policy-dcat-ap">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/ProvenanceStatement">
+    <skos:scopeNote xml:lang="en">A statement of any changes in ownership and custody of a resource since its creation that are significant for its authenticity, integrity, and interpretation. This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is only used as the range of the optional property ''dct:provenance'' for class Dataset. In mobilityDCAT-AP, however, this property is removed. Thus, this class SHOULD NOT be used but is kept for compatibility reasons with [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/Standard">
+    <skos:scopeNote xml:lang="en">A standard or other specification to which a Catalogue, Catalogue Record, Data Service, Dataset, or Distribution conforms.. This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is used as the range of property ''dct:conformsTo'' for class Catalogue Record (context ''application profile''); for class Dataset (context' 'conforms to''); and for class Distribution (context ''linked schemas''). In mobilityDCAT-AP, these properties are removed. However, mobilityDCAT-AP uses this class as the range of an added property ''dct:conformsTo'' for class Dataset in a different context ''reference system'', analogue to a property addition by [GEODCAT-AP-v2.0.0]. [GEODCAT-AP-v2.0.0] adds several properties to the class Standard. These describe any standards via an identifier, type, release date etc. However, describing standards is not a main use case of mobilityDCAT-AP, so no properties are added here. If necessary, the properties for class Standard, as added by [GEODCAT-AP-v2.0.0], MAY be used.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#endDate">
+    <skos:scopeNote xml:lang="en">This property contains the end of the Period of Time.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#servesDataset">
+    <skos:scopeNote xml:lang="en">This property refers to a Dataset that this Data Service can distribute.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/title">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <skos:scopeNote xml:lang="en">This property contains a name given to the mobility data portal, a name of the Category Scheme, a name given to the Data Service, a name given to the Dataset in a generic term. The name should be a meaningful, unique and unambiguous label. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. The language versions should correspond to property dct:language of class Catalogue Record. I.e., if more than one language is provided as a metadata language, there should be as many language versions for the title.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/dateCopyrighted">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/hasPart">
+    <skos:scopeNote xml:lang="en">This property refers to a related Catalogue that is part of the described mobility data portal. This property could be used to link the mobility data portal to another data portal, by e.g. harvesting metadata from this other portal into the mobility data portal. </skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/Location">
+    <skos:scopeNote xml:lang="en">A spatial region or named place. It can be represented via a named place (controlled vocabulary) or with geographic coordinates, according to DCAT-AP guidelines [DCAT-AP-guideline-spatial]. For mobility data portals, usage of a named place is preferred. Many mobility data providers represent public authorities such as states, regions, municipalities etc., which can be easily represented via named places. In contrast, defining of coordinates per data set might be error-prone and inconsistent. As named spaces, identifiers SHOULD be used (via property ''dct:identifier''). These are coded via controlled vocabularies such as the EU authority tables, NUTS (Nomenclature des unités territoriales statistiques) or Geonames, see § 5.2 Controlled vocabularies to be used. Alternatively, geographic clear names MAY be used via property ''skos:prefLabel''. The ''skos:inScheme'' and ''dct:identifier'' recommended properties are not included in [DCAT-AP-v2.0.1]. The ''skos:prefLabel'' optional property is not included in [DCAT-AP-v2.0.1]. Please note that the order of usage is as follows: use the most specific geospatial relationship by preference. E.g. if the spatial description is a bbox, use ''dcat:bbox'', otherwise use ''locn:geometry'' (see § 4.16.2 Optional properties for Location).</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Kind">
+    <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this class is used as the range of the recommended property dcat:contactPoint for class Dataset. Properties vcard:fn and vcard:hasEmail are mandatory when an instance of this class is present.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/isReferencedBy">
+    <skos:scopeNote xml:lang="en">This property references, cites, or otherwise points to another, related dataset. Corresponds to the property dct:relation, with a contrary relationship. It may be a link between two individual datasets that complement each other, e.g. one dataset with static parking data, and one with dynamic parking data, both covering the same parking facilities.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/Agent">
+    <skos:scopeNote xml:lang="en">An entity (e.g., an individual or an organisation) that is associated with Catalogues, Catalogue Records, or Datasets. If the Agent is an organisation, the use of the Organization Ontology [VOCAB-ORG] is recommended. See § 7. Agent Types, Agent Roles and Agent Properties for a discussion on Agent types, roles and properties. The ''foaf:mbox'' mandatory property is not included in [DCAT-AP-v2.0.1]. The ''foaf:workplaceHomepage'' recommended property is not included in [DCAT-AP-v2.0.1], The ''locn:address'', ''org:memberOf'', ''foaf:firstName'', ''foaf:phone'', ''foaf:surname'' optional properties are not included in [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#bbox">
+    <skos:scopeNote xml:lang="en">This property refers to the geographic bounding box of a resource.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/LicenseDocument">
+    <skos:scopeNote xml:lang="en">A legal document giving official permission to do something with a resource. The ''dct:identifier'' recommended property is not included in [DCAT-AP-v2.0.1]. The licence type recommended property is removed from [DCAT-AP-v2.0.1]. The ''rdfs:label'' optional property is not included in [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#accessURL">
+    <skos:scopeNote xml:lang="en">This property contains a URL that gives access to a Distribution of the Dataset. Depending on the type of data provision, there are different options for describing the URL. For data services, e.g., API, broker services, data feeds, etc., the URL MAY be the end point of such service. However, if some agreements between the data provider and the data user need to be established first, the access URL may link to web page, where the access is further arranged, e.g., initiating a a subscription process. For data which can be downloaded directly, the download URL should be copied from the optional property dcat:downloadURL. For other cases, where data cannot be directly accessed or downloaded via the platform, the access URL MAY be a link to an external service or a website which enables access to the data. This way, this property is the primary key to link to a data service. There is also specific class dcat:DataService, which can be linked via property dcat:accessService. See § 4.9 Data Service for a usage note about the class Data Service.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/isPartOf">
+    <skos:scopeNote xml:lang="en">This property refers to a related Catalogue in which the described mobility data portal is physically or logically included. This property could be used to link the mobility data portal to another data portal, by e.g. harvesting metadata from the mobility data portal into this other portal. </skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/vocab/vann/preferredNamespacePrefix">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/PeriodOfTime">
+    <skos:scopeNote xml:lang="en">An interval of time that is named or defined by its start and end dates. Please note that while both properties are recommended, one of the two must be present for each instance of the class ''dct:PeriodOfTime'', if such an instance is present. The start of the period should be understood as the start of the date, hour, minute etc. given (e.g. starting at midnight at the beginning of the day if the value is a date); the end of the period should be understood as the end of the date, hour, minute etc. given (e.g. ending at midnight at the end of the day if the value is a date). The beginning and end properties are removed from [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/abstract">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#endpointURL">
+    <skos:scopeNote xml:lang="en">The root location or primary endpoint of the Service (an IRI).</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#Dataset">
+    <skos:scopeNote xml:lang="en">A dataset is a collection of data, published or curated by a single source, and available for access or download at the mobility data portal in one or more distributions. In the context of mobility-related data exchange, this might be, e.g., a data collection about static parking information for truck drivers, published by a road authority.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/alternative">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#Catalog">
+    <skos:scopeNote xml:lang="en">A concrete mobility data portal, i.e, a web portal, where mobility-related datasets and their distributions are described via metadata and discoverable for data users.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://www.w3.org/TR/vocab-dcat-2/">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/format">
+    <skos:scopeNote xml:lang="en">This property refers to the technical syntax of the delivered content within the Distribution. It describes the base standard that specifies syntactically correct documents. On this level, only base elements of building documents properly are specified and can be proved by syntax checks. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. The obligation of this property is raised to “mandatory”, compared to [DCAT-AP-v2.0.1]. There is a similar property in [DCAT-AP-v2.0.1] dcat:mediaType, which is removed in mobilityDCAT-AP. There reason is the use of Controlled vocabularies: dct:format uses the EU Authority List [EUV-FT], whereas dcat:mediaType uses the IANA media types [IANA-MEDIA-TYPES]. The first one, however, is sufficient to describe the syntaxes commonly used in mobility data portals. </skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/accrualPeriodicity">
+    <skos:scopeNote xml:lang="en">This property describes how often the delivered content is updated. This information tells a data consumer, how often it is updated on the on the data platform, so the data consumer might align the frequency of data retrieval accordingly. For data services, e.g., data feeds, the frequency should correspond to the technical upload / data push frequency. For static data sets, it should correspond to the expected change frequency (see property dct:modified). The frequency might be a specific time interval, or a general remark such as “updated on occurrence”. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. The obligation of this property is raised to “mandatory”, compared to [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#Distribution">
+    <skos:scopeNote xml:lang="en">A distribution describes the data formats and communication methods for a dataset. There may be one or multiple distributions for one dataset. For example, the same data set (e.g. static parking information for truck drivers) can be provided in different ways e.g. as downloadable zip file or as XML using a SOAP web service. These are two distributions based on one data set. In [DCAT-AP-v2.0.1], this class has been classified as ‘Recommended’, to allow for cases that a particular Dataset does not have a Distribution, i.e. . However, for the context of mobility data portals, it can be expected that all datasets have one or more Distributions. Thus, the obligation of class Distribution is raised to mandatory, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/creator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/adms#versionNotes">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <skos:scopeNote xml:lang="en">This property contains a textual description of the differences between this version and a previous version of the dataset, as an addition to the property owl:versionInfo. This property can be repeated for parallel language versions of the version notes - see § 8. Accessibility and Multilingual Aspects.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#centroid">
+    <skos:scopeNote xml:lang="en">This property refers to the geographic centre (centroid) of a resource.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/rights">
+    <skos:scopeNote xml:lang="en">This property links to a Rights Statement, i.e., a statement about the intellectual property rights (IPR). As a minimum, it should include an information on the type of conditions for access and usage. A concrete (standard) license can be referred via the recommended property dct:license. The obligation of this property is raised to “mandatory”, compared to [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/Document">
+    <skos:scopeNote xml:lang="en">A textual resource intended for human consumption that contains information, e.g., a Web page about a Dataset.  This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is only used as the range of the recommended properties ''foaf:homepage'' for class Catalogue; the optional properties ''foaf:page'' and ''dcat:landingPage'' for class Dataset; and the optional property ''foaf:page'' for class Distribution. In mobilityDCAT-AP, however, the range of ''foaf:homepage'' for class Catalogue is changed to the more generic range ''rdfs:Resource''. The other, above-mentioned properties are removed. Thus, this class SHOULD NOT be used, but is kept for compatibility reasons with [DCAT-AP-v2.0.1]</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/spatial">
+    <skos:scopeNote xml:lang="en">This property refers to a country code where the data platform is hosted. For National Access Points (NAPs), this corresponds to the EC Member State or a country that installs such NAP. The property might be used for analyses about available data sets per country, or to identify country-specific metadata in case metadata are federated from multiple national portals into an international portal. It is not to be mixed up with country codes used within the dataset property dct:spatial, which might be different. The obligation of this property is raised to “mandatory”, comparing to [DCAT-AP-v2.0.1].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core#Concept">
+    <skos:scopeNote xml:lang="en">A category of a dataset, i.e. a specific subject, theme, or a class about its content. The category is described via a categorisation scheme, i.e. a classification or a taxonomy. Such scheme lists all potential categories, see class ''Category Scheme''. In mobilityDCAT-AP, this class SHOULD only be used in the context of a data set (via property ''dcat:theme''). In other contexts, e.g. under [geoDCAT-AP-v2.0.0], this might also be used to describe the theme of a Catalogue or Data Service.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#theme">
+    <skos:scopeNote xml:lang="en">The values to be used for this property are the URIs of the concepts in the vocabulary. This is a vocabulary created by mobilityDCAT-AP. There are two hierarchical levels: ''Data content category'' (mandatory) and ''Data content sub-category'' (optional), see the usage note for property ''dcat:theme''.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#Relationship">
+    <skos:scopeNote xml:lang="en">An association class for attaching additional information to a relationship between DCAT Resources</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/accessRights">
+    <skos:scopeNote xml:lang="en">This property MAY include information regarding access or restrictions based on privacy, security, or other policies. For INSPIRE metadata, this property SHOULD be used with the URIs of the ''Limitations on public access'' code list operated by the INSPIRE Registry [INSPIRE-LPA].</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/hasVersion">
+    <skos:scopeNote xml:lang="en">This property refers to a related dataset that is a version, edition, or adaptation of the described dataset. Corresponds to the property ''dct:isVersionOf'', with a contrary relationship. It might be used to host multiple versions of the same data set in the data portal, also enabling a version history. Multiple versions should be differentiated via the properties ''owl:versionInfo'' and ''adms:versionNotes''.</skos:scopeNote>
+  </rdf:Description>
 </rdf:RDF>
-
-
-
-<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->

--- a/drafts/1.1.0-draft-0.1/mobilitydcat-ap_v1.1.0.ttl
+++ b/drafts/1.1.0-draft-0.1/mobilitydcat-ap_v1.1.0.ttl
@@ -8,8 +8,8 @@
 @prefix dqv: <http://www.w3.org/ns/dqv#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
-@prefix mobilitydcatap: <http://w3id.org/mobilitydcat-ap#> .
-@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix mobilitydcatap: <https://w3id.org/mobilitydcat-ap#> .
+@prefix oa: <https://www.w3.org/ns/oa#> .
 @prefix org: <http://www.w3.org/ns/org#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,7 +31,8 @@ mobilitydcatap: a voaf:Vocabulary,
     adms:Asset ;
   rdfs:label "mobilityDCAT-AP"@en ;
   dct:abstract "mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. "@en ;
-  dct:alternative "mobilityDCAT-AP - Version 1.0.0: A mobility extension for the DCAT application profile for data portals in Europe"@en ;
+  dct:alternative "mobilityDCAT-AP - Version 1.1.0: A mobility extension for the DCAT application profile for data portals in Europe"@en ;
+  skos:altLabel   "mobilityDCAT-AP - Version 1.1.0: A mobility extension for the DCAT application profile for data portals in Europe"@en ;
   dct:conformsTo dcatap:,
     <https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements>,
     <https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/document/change-and-release-management-policy-dcat-ap>,
@@ -42,9 +43,9 @@ mobilitydcatap: a voaf:Vocabulary,
       foaf:page <https://github.com/mobilityDCAT-AP/mobilityDCAT-AP> ] ;
   dct:dateCopyrighted "2023"^^xsd:gYear ;
   dct:description "mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. "@en ;
-  dct:issued "2023-05-11"^^xsd:date ;
+  dct:issued   "2025-01-17"^^xsd:date ;
+  dct:modified "2025-01-17"^^xsd:date ;
   dct:license <https://creativecommons.org/licenses/by/4.0/> ;
-  dct:modified "2023-10-15"^^xsd:date ;
   dct:publisher <https://napcore.eu/> ;
   dct:rightsHolder <https://napcore.eu/> ;
   dct:title "mobilityDCAT-AP"@en ;
@@ -55,66 +56,49 @@ mobilitydcatap: a voaf:Vocabulary,
       foaf:name "Lina Molinas Comet" ],
     <https://lina-molinas-comet.name/foaf/#me> ;
   vann:preferredNamespacePrefix "mobilitydcatap" ;
-  vann:preferredNamespaceUri "http://w3id.org/mobilitydcat-ap/"^^xsd:anyURI ;
-  voaf:reliesOn dcatap:,
-    dct:,
-    spdx:,
-    rdfs:,
-    owl:,
-    skos:,
-    vcard:,
-    cnt:,
-    adms:,
-    dcat:,
-    dqv:,
-    locn:,
-    org:,
-    prov:,
-    foaf: ;
+  vann:preferredNamespaceUri "https://w3id.org/mobilitydcat-ap#"^^xsd:anyURI ;
+  voaf:reliesOn dcatap:, dct:, spdx:, rdfs:, owl:, skos:, vcard:, cnt:, adms:, dcat:, dqv:, locn:, org:, prov:, foaf: ;
   rdfs:comment "mobilityDCAT-AP is an extension of the DCAT application profile for data portals in Europe (DCAT-AP) [DCAT-AP]. It allows for a structured, interoperable and harmonised way to describe and exchange metadata about datasets and data services with a mobility relevance. "@en ;
-  rdfs:isDefinedBy <http://w3id.org/mobilityDCAT-AP/releases/1.0.0/> ;
-  owl:backwardCompatibleWith <http://w3id.org/mobilityDCAT-AP/releases/1.0.0/>;
-  owl:priorVersion <http://w3id.org/mobilityDCAT-AP/releases/1.0.0/> ;
-  owl:versionIRI <http://w3id.org/mobilityDCAT-AP/releases/1.0.0/> ;
-  owl:versionInfo "Version 1.0.0"@en ;
-  skos:altLabel "mobilityDCAT-AP - Version 1.0.0: A mobility extension for the DCAT application profile for data portals in Europe"@en ;
-  adms:last mobilitydcatap: ;
-  adms:prev <http://w3id.org/mobilitydcat-ap/releases/1.0.0/> ;
+  rdfs:isDefinedBy <https://w3id.org/mobilitydcat-ap/releases/1.1.0/> ;
+  owl:backwardCompatibleWith <https://w3id.org/mobilitydcat-ap/releases/1.0.1/> ;
+  owl:priorVersion <https://w3id.org/mobilitydcat-ap/releases/1.0.1/> ;
+  owl:versionIRI <https://w3id.org/mobilitydcat-ap/releases/1.1.0/> ;
+  owl:versionInfo "Version 1.1.0"@en ;
+  adms:last <https://w3id.org/mobilitydcat-ap/releases/1.1.0/> ;
+  adms:prev <https://w3id.org/mobilitydcat-ap/releases/1.0.1/> ;
   adms:status <http://publications.europa.eu/resource/dataset/dataset-status/COMPLETED> ;
-  adms:versionNotes "This version of mobilityDCAT-AP extends [DCAT-AP-v2.0.1] with 2 additional classes and 48 additional properties (some of which re-used across classes)."@en ;
+  adms:versionNotes "mobilityDCAT-AP 1.1.0 extends mobilityDCAT-AP 1.0.1. Key changes: added dct:source property for Catalogue Record (harvesting use cases); changed cardinality of mobilitydcatap:schema from 0..1 to 0..n; added dct:conformsTo optional property for Mobility Data Standard. Errata corrections and UML diagram updates included."@en ;
   dcat:distribution [ a adms:AssetDistribution ;
-      dct:format <http://publications.europa.eu/resource/authority/file-type/JSON_LD>,
-        <http://www.w3.org/ns/formats/data/JSON-LD> ;
-      dct:title "JSON-LD"@en ;
-      adms:representationTechnique <http://purl.org/adms/representationtechnique/OWL>,
-        <http://purl.org/adms/representationtechnique/RDFSchema> ;
-      dcat:downloadURL <http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.jsonld> ;
-      dcat:mediaType <https://www.iana.org/assignments/media-types/application/ld+json> ],
-    [ a adms:AssetDistribution ;
-      dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE>,
-        <http://www.w3.org/ns/formats/data/Turtle> ;
-      dct:title "Turtle"@en ;
-      adms:representationTechnique <http://purl.org/adms/representationtechnique/OWL>,
-        <http://purl.org/adms/representationtechnique/RDFSchema> ;
-      dcat:downloadURL <http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.ttl> ;
-      dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ],
-    [ a adms:AssetDistribution ;
-      dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_XML>,
-        <http://www.w3.org/ns/formats/data/RDF_XML> ;
-      dct:title "RDF/XML"@en ;
-      adms:representationTechnique <http://purl.org/adms/representationtechnique/OWL>,
-        <http://purl.org/adms/representationtechnique/RDFSchema> ;
-      dcat:downloadURL <http://w3id.org/mobilitydcat-ap/releases/1.0.0/mobilitydcat-ap.rdf> ;
-      dcat:mediaType <https://www.iana.org/assignments/media-types/application/rdf+xml> ],
-    [ a adms:AssetDistribution ;
-      dct:format <http://publications.europa.eu/resource/authority/file-type/HTML> ;
-      dct:title "HTML"@en ;
-      adms:representationTechnique <http://purl.org/adms/representationtechnique/HumanLanguage> ;
-      dcat:downloadURL <http://w3id.org/mobilitydcat-ap/releases/1.0.0/> ;
-      dcat:mediaType "text/html"^^dct:IMT ] ;
-      foaf:depiction <https://mobilitydcat-ap.github.io/mobilityDCAT-AP/drafts/latest/mobilityDCAT-AP_uml-diagramm_230719.png> .
-
-
+        dct:format <http://publications.europa.eu/resource/authority/file-type/JSON_LD>,
+          <http://www.w3.org/ns/formats/data/JSON-LD> ;
+        dct:title "JSON-LD"@en ;
+        adms:representationTechnique <http://purl.org/adms/representationtechnique/OWL>,
+          <http://purl.org/adms/representationtechnique/RDFSchema> ;
+        dcat:downloadURL <https://w3id.org/mobilitydcat-ap/releases/1.1.0/mobilitydcat-ap.jsonld> ;
+        dcat:mediaType <https://www.iana.org/assignments/media-types/application/ld+json> ],
+      [ a adms:AssetDistribution ;
+        dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE>,
+          <http://www.w3.org/ns/formats/data/Turtle> ;
+        dct:title "Turtle"@en ;
+        adms:representationTechnique <http://purl.org/adms/representationtechnique/OWL>,
+          <http://purl.org/adms/representationtechnique/RDFSchema> ;
+        dcat:downloadURL <https://w3id.org/mobilitydcat-ap/releases/1.1.0/mobilitydcat-ap.ttl> ;
+        dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ],
+      [ a adms:AssetDistribution ;
+        dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_XML>,
+          <http://www.w3.org/ns/formats/data/RDF_XML> ;
+        dct:title "RDF/XML"@en ;
+        adms:representationTechnique <http://purl.org/adms/representationtechnique/OWL>,
+          <http://purl.org/adms/representationtechnique/RDFSchema> ;
+        dcat:downloadURL <https://w3id.org/mobilitydcat-ap/releases/1.1.0/mobilitydcat-ap.rdf> ;
+        dcat:mediaType <https://www.iana.org/assignments/media-types/application/rdf+xml> ],
+      [ a adms:AssetDistribution ;
+        dct:format <http://publications.europa.eu/resource/authority/file-type/HTML> ;
+        dct:title "HTML"@en ;
+        adms:representationTechnique <http://purl.org/adms/representationtechnique/HumanLanguage> ;
+        dcat:downloadURL <https://w3id.org/mobilitydcat-ap/releases/1.1.0/> ;
+        dcat:mediaType "text/html"^^dct:IMT ] ;
+    foaf:depiction <https://mobilitydcat-ap.github.io/mobilityDCAT-AP/drafts/1.1.0-draft-0.1/figures/mobilityDCAT-AP_uml-diagramm_240816.png> .
 
 #################################################################
 #    Annotation properties
@@ -123,99 +107,71 @@ mobilitydcatap: a voaf:Vocabulary,
 ###  http://purl.org/dc/terms/abstract
 dct:abstract rdf:type owl:AnnotationProperty .
 
-
 ###  http://purl.org/dc/terms/alternative
 dct:alternative rdf:type owl:AnnotationProperty .
-
-
-###  http://purl.org/dc/terms/conformsTo
-dct:conformsTo rdf:type owl:AnnotationProperty .
-
 
 ###  http://purl.org/dc/terms/contributor
 dct:contributor rdf:type owl:AnnotationProperty .
 
-
 ###  http://purl.org/dc/terms/created
 dct:created rdf:type owl:AnnotationProperty .
-
 
 ###  http://purl.org/dc/terms/creator
 dct:creator rdf:type owl:AnnotationProperty .
 
-
 ###  http://purl.org/dc/terms/dateCopyrighted
 dct:dateCopyrighted rdf:type owl:AnnotationProperty .
-
 
 ###  http://purl.org/dc/terms/description
 dct:description rdf:type owl:AnnotationProperty .
 
-
 ###  http://purl.org/dc/terms/issued
 dct:issued rdf:type owl:AnnotationProperty .
-
 
 ###  http://purl.org/dc/terms/license
 dct:license rdf:type owl:AnnotationProperty .
 
-
 ###  http://purl.org/dc/terms/modified
 dct:modified rdf:type owl:AnnotationProperty .
-
 
 ###  http://purl.org/dc/terms/publisher
 dct:publisher rdf:type owl:AnnotationProperty .
 
-
 ###  http://purl.org/dc/terms/rightsHolder
 dct:rightsHolder rdf:type owl:AnnotationProperty .
-
 
 ###  http://purl.org/dc/terms/title
 dct:title rdf:type owl:AnnotationProperty .
 
-
 ###  http://purl.org/dc/terms/type
 dct:type rdf:type owl:AnnotationProperty .
-
 
 ###  http://purl.org/vocab/vann/preferredNamespacePrefix
 vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
 
-
 ###  http://purl.org/vocab/vann/preferredNamespaceUri
 vann:preferredNamespaceUri rdf:type owl:AnnotationProperty .
-
 
 ###  http://www.w3.org/2000/01/rdf-schema#label
 rdfs:label rdf:type owl:AnnotationProperty .
 
-
 ###  http://www.w3.org/2002/07/owl#backwardCompatibleWith
 owl:backwardCompatibleWith rdf:type owl:AnnotationProperty .
-
 
 ###  http://www.w3.org/2004/02/skos/core#altLabel
 skos:altLabel rdf:type owl:AnnotationProperty .
 
-
 ###  http://www.w3.org/ns/prov#component
 prov:component rdf:type owl:AnnotationProperty .
-
 
 ###  http://xmlns.com/foaf/0.1/depiction
 foaf:depiction rdf:type owl:AnnotationProperty .
 
-
 ###  http://xmlns.com/foaf/0.1/name
 foaf:name rdf:type owl:AnnotationProperty .
 
-
 ###  http://www.w3.org/ns/adms#versionNotes
 adms:versionNotes  rdf:type owl:AnnotationProperty .
-
-
 
 #################################################################
 #    Classes
@@ -229,7 +185,7 @@ mobilitydcatap:MobilityDataStandard rdf:type owl:Class ;
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a mandatory class."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> .
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> .
 		   
 ### http://www.w3.org/ns/locn#Address
 locn:Address rdf:type owl:Class ;
@@ -237,7 +193,7 @@ locn:Address rdf:type owl:Class ;
            rdfs:label "Address (Agent)"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional class."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> .
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> .
 		   
 ###  https://w3id.org/mobilitydcatap#Assessment
 mobilitydcatap:Assessment rdf:type owl:Class ;
@@ -246,7 +202,7 @@ mobilitydcatap:Assessment rdf:type owl:Class ;
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional class."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> .		   
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> .		   
 		   
 ### http://www.w3.org/ns/dqv#hasQualityAnnotation
 dqv:QualityAnnotation rdf:type owl:Class ;
@@ -254,7 +210,7 @@ dqv:QualityAnnotation rdf:type owl:Class ;
            rdfs:label "Quality Annotation"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional class."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> .
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> .
 
 
 #################################################################
@@ -267,59 +223,49 @@ locn:address a rdf:Property,
            rdfs:comment "This property MAY be used to specify the postal address of the Agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
            rdfs:label "address"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Agent"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes locn:Address ;
-           dcam:rangeIncludes locn:Address .
-		   
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
+           dcam:domainIncludes foaf:Agent ;   
+           dcam:rangeIncludes locn:Address .   
+
 ###  http://www.w3.org/ns/org#memberOf
 org:memberOf a rdf:Property,
            owl:ObjectProperty ;
            rdfs:comment "If the agent is of type person, this property SHOULD be used to specify the affiliation of the Agent, see § 7. Agent Types, Agent Roles and Contact Information. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
            rdfs:label "affiliation"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Agent"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes locn:Address ;
-           dcam:rangeIncludes org:Organization .
-		   
-###  http://xmlns.com/foaf/0.1/#term_mbox
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
+           dcam:domainIncludes foaf:Agent ;     
+           dcam:rangeIncludes org:Organization . 
+
+###  http://xmlns.com/foaf/0.1/mbox
 foaf:mbox a rdf:Property,
-		   owl:ObjectProperty ;
+           owl:ObjectProperty ;
            rdfs:comment "This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
            rdfs:label "email"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is a mandatory property to be used for Agent"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes locn:Address ;
-           dcam:rangeIncludes owl:Thing .
-		   
-###  http://xmlns.com/foaf/0.1/#term_phone
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
+           dcam:domainIncludes foaf:Agent ; 
+           dcam:rangeIncludes owl:Thing .    
+
+###  http://xmlns.com/foaf/0.1/phone
 foaf:phone a rdf:Property,
            owl:ObjectProperty ;
            rdfs:comment "This property MAY be used to provide the phone number of the Agent, specified using fully qualified tel: URI scheme [RFC3966]. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
            rdfs:label "phone"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Agent"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes locn:Address ;
-           dcam:rangeIncludes owl:Thing .
-		   
-###  http://xmlns.com/foaf/0.1/#term_workplaceHomepage
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
+           dcam:domainIncludes foaf:Agent ; 
+           dcam:rangeIncludes owl:Thing .    
+
+###  http://xmlns.com/foaf/0.1/workplaceHomepage
 foaf:workplaceHomepage a rdf:Property,
            owl:ObjectProperty ;
            rdfs:comment "This property MAY be used to specify the Web site of the Agent."@en ;
            rdfs:label "URL"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Agent"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes locn:Address ;
-           dcam:rangeIncludes rdfs:Resource .
-
-###   http://www.w3.org/ns/oa#hasBody
-oa:hasBody a rdf:Property,
-           owl:ObjectProperty ;
-           rdfs:comment "This property MAY be used to describe the result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes."@en ;
-           rdfs:label "assessment result"@en ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Assessment. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes mobilitydcatap:Assessment ;
-           dcam:rangeIncludes rdfs:Resource .	   		   	   
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
+           dcam:domainIncludes foaf:Agent ;   
+           dcam:rangeIncludes rdfs:Resource .  		   	   
 		   
 ###   http://www.w3.org/ns/adms#identifier 
 adms:identifier a rdf:Property,
@@ -327,7 +273,7 @@ adms:identifier a rdf:Property,
            rdfs:comment "This property MAY be used as an additional identifier, besides dct:identifier. It MAY be referring to a dedicated, EU-wide identificator system of NAPS or other portals, to be introduced in the future."@en ;
            rdfs:label "other identifier"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Catalogue. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Catalog ;
            dcam:rangeIncludes adms:Identifier .				   
 		   
@@ -338,7 +284,7 @@ dct:publisher a rdf:Property,
            rdfs:label "publisher"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Catalogue Record."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:CatalogRecord ;
            dcam:rangeIncludes foaf:Agent .		   
 
@@ -349,19 +295,20 @@ dct:source a rdf:Property,
            rdfs:label "source metadata"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Catalogue Record."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:CatalogRecord ;
            dcam:rangeIncludes dcat:CatalogRecord .	
 
 ###  http://www.w3.org/2004/02/skos/core#inScheme
 skos:inScheme a rdf:Property,
            owl:ObjectProperty ;
-           rdfs:comment "This property MAY be used to specify the Category Scheme to which the Category belongs. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
-           rdfs:label "category scheme"@en  ;
+           rdfs:comment "This property MAY be used to specify the Category Scheme to which the Category belongs, or the gazetteer to which the Location belongs. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
+           rdfs:label "category scheme / gazetteer"@en ;
            vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for  Category."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           skos:scopeNote "In mobilityDCAT-AP, this is an optional property for Category and a recommended property for Location."@en ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes skos:Concept ;
+           dcam:domainIncludes dct:Location ;
            dcam:rangeIncludes skos:ConceptScheme .
 		   
 ###  https://w3id.org/mobilitydcat-ap#mobilityTheme
@@ -372,7 +319,7 @@ mobilitydcatap:mobilityTheme a rdf:Property,
            rdfs:label "mobility theme"@en  ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a mandatory property to be used for  Dataset."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes skos:Concept .		   	   
 
@@ -384,22 +331,23 @@ mobilitydcatap:georeferencingMethod a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Datasets."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes skos:Concept .
 		   
 ###  http://purl.org/dc/terms/conformsTo
 dct:conformsTo a rdf:Property,
            owl:ObjectProperty ;
-           rdfs:comment "This property SHOULD be used to specify the spatial reference system used in the dataset. Spatial reference systems SHOULD be specified by using the corresponding URIs from the “EPSG coordinate reference systems” register operated by OGC [OGC-EPSG]. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]. "@en ;
-           rdfs:label "reference system"@en ;
+           rdfs:label "reference system / standard name"@en ;
+           rdfs:comment "Used as reference system for Dataset (range dct:Standard) and as standard name for MobilityDataStandard (range skos:Concept)."@en ;
            vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Dataset. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           skos:scopeNote "In mobilityDCAT-AP, this is a recommended property for Dataset and an optional property for Mobility Data Standard."@en ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
-           dcam:rangeIncludes dct:Standard .
+           dcam:domainIncludes mobilitydcatap:MobilityDataStandard ;
+           dcam:rangeIncludes dct:Standard ;
+           dcam:rangeIncludes skos:Concept .
 	
-
 ###  http://purl.org/dc/terms/rightsHolder
 dct:rightsHolder a rdf:Property,
            owl:ObjectProperty ;
@@ -407,7 +355,7 @@ dct:rightsHolder a rdf:Property,
            rdfs:label "rights holder"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Dataset. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes foaf:Agent .
 		   
@@ -420,7 +368,7 @@ mobilitydcatap:networkCoverage a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Datasets."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes skos:Concept .
 		   
@@ -432,7 +380,7 @@ mobilitydcatap:transportMode a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Datasets."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes skos:Concept .
 		   
@@ -441,10 +389,9 @@ dcatap:applicableLegislation a rdf:Property,
            owl:ObjectProperty ;
            rdfs:comment "This property MAY refer to one or several legal frameworks being relevant for the dataset, e.g., an EC Delegated Regulation which constitutes the purpose of the corresponding data platform (here called National Access Point/NAP), or some other international or national frameworks, e.g., Open Data regulations. For European legal frameworks, it is recommended to use the European Legislation Identifier [ELI] to refer to legislation whenever possible. This property is derived from the DCAT-AP HVD extension [DCAT-AP-HVD]."@en ;
            rdfs:label "applicable legislation"@en ;
-           rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Datasets."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes skos:Concept .		   
 
@@ -456,7 +403,7 @@ mobilitydcatap:assessmentResult a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Datasets."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes mobilitydcatap:Assessment .
 		   
@@ -468,7 +415,7 @@ mobilitydcatap:intendedInformationService a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Datasets."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes skos:Concept .		   
 		   
@@ -480,7 +427,7 @@ dqv:hasQualityAnnotation a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Datasets."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes dqv:QualityAnnotation .
 
@@ -493,7 +440,7 @@ mobilitydcatap:mobilityDataStandard a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a mandatory property to be used for Distributions."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Distribution ;
            dcam:rangeIncludes mobilitydcatap:MobilityDataStandard .
 		   
@@ -505,7 +452,7 @@ mobilitydcatap:applicationLayerProtocol a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this property is recommended to be used for Distributions."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Distribution ;
            dcam:rangeIncludes skos:Concept .		   
 		   
@@ -517,7 +464,7 @@ mobilitydcatap:communicationMethod a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Distributions."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Distribution ;
            dcam:rangeIncludes skos:Concept .		   
 		   
@@ -530,7 +477,7 @@ mobilitydcatap:grammar a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Distributions."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Distribution ;
            dcam:rangeIncludes skos:Concept .
 
@@ -541,7 +488,7 @@ adms:sample a rdf:Property,
            rdfs:label "sample"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Distributions."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Distribution ;
            dcam:rangeIncludes rdfs:Resource .
 
@@ -552,7 +499,7 @@ dct:temporal a rdf:Property,
            rdfs:label "temporal coverage"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Distributions."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Distribution ;
            dcam:rangeIncludes dct:PeriodOfTime .
 		   
@@ -563,7 +510,7 @@ vcard:hasEmail a rdf:Property,
            rdfs:label "email"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Kind."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes vcard:Kind ;
            dcam:rangeIncludes owl:Thing .
 
@@ -574,7 +521,7 @@ vcard:hasURL a rdf:Property,
            rdfs:label "URL"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Kind."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes vcard:Kind ;
            dcam:rangeIncludes owl:Thing .
 	
@@ -585,7 +532,7 @@ vcard:hasAddress a rdf:Property,
            rdfs:label "address"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Kind."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes vcard:Kind ;
            dcam:rangeIncludes vcard:Address .
 
@@ -596,31 +543,18 @@ vcard:hasTelephone a rdf:Property,
            rdfs:label "phone"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Kind."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes vcard:Kind ;
            dcam:rangeIncludes owl:Thing .
 
 ###  http://purl.org/dc/terms/identifier
 dct:identifier a rdf:Property,
-           owl:ObjectProperty ;
-           rdfs:comment "This property MAY be be used to link to a concrete standard license. A controlled vocabulary § 5.2 Controlled vocabularies to be used is provided.  "@en ;
-           rdfs:label "standard licence"@en ;
-           vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Licence Document "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+            owl:AnnotationProperty ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dct:LicenseDocument ;
-           dcam:rangeIncludes skos:Concept .
-
-###  http://www.w3.org/2004/02/skos/core#inScheme
-skos:inScheme a rdf:Property,
-           owl:ObjectProperty ;
-           rdfs:comment "This property MAY be used to specify the gazetteer to which the Location belongs. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
-           rdfs:label "gazetteer"@en ;
-           vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for  Location."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           dcam:domainIncludes dcat:Catalog ;
            dcam:domainIncludes dct:Location ;
-           dcam:rangeIncludes skos:ConceptScheme .
+           dcam:rangeIncludes rdfs:Literal .
 
 ###  https://w3id.org/mobilitydcat-ap#schema
 mobilitydcatap:schema a rdf:Property,
@@ -631,7 +565,7 @@ mobilitydcatap:schema a rdf:Property,
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes mobilitydcatap:MobilityDataStandard ;
            dcam:rangeIncludes rdfs:Resource .
 	
@@ -641,7 +575,7 @@ oa:hasTarget a rdf:Property,
            rdfs:comment "This property MAY be used to describe the target of the quality annotation, referring back to the dataset being described. I.e., it is the inverse property of “dqv:hasQualityAnnotation” for class Dataset."@en ;
            rdfs:label "quality annotation target"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Quality Annotation. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dqv:QualityAnnotation ;
            dcam:rangeIncludes dcat:Dataset .		
 
@@ -652,7 +586,7 @@ dct:type a rdf:Property,
            rdfs:label "conditions for access and usage"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a mandatory property to be used for Rights Statement."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dct:RightsStatement ;
            dcam:rangeIncludes skos:Concept .
 		 
@@ -666,7 +600,7 @@ locn:adminUnitL2 rdf:type owl:DatatypeProperty ;
            rdfs:comment "The administrative area of an Address of the Agent. Depending on the country, this corresponds to a province, a county, a region, or a state."@en ;
            rdfs:label "administrative area"@en  ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes locn:Address ;
            dcam:rangeIncludes rdfs:Literal .
 		   
@@ -675,7 +609,7 @@ locn:postName rdf:type owl:DatatypeProperty ;
            rdfs:comment "The city of an Address of the Agent."@en ;
            rdfs:label "city"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes locn:Address ;
            dcam:rangeIncludes rdfs:Literal .
 		   
@@ -684,7 +618,7 @@ locn:adminUnitL1 rdf:type owl:DatatypeProperty ;
            rdfs:comment "The country of an Address of the Agent."@en ;
            rdfs:label "country"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes locn:Address ;
            dcam:rangeIncludes rdfs:Literal .
 
@@ -693,7 +627,7 @@ locn:postCode rdf:type owl:DatatypeProperty ;
            rdfs:comment "The postal code of an Address of the Agent."@en ;
            rdfs:label "postal code"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes locn:Address ;
            dcam:rangeIncludes rdfs:Literal .
 		   
@@ -702,7 +636,7 @@ locn:thoroughfare rdf:type owl:DatatypeProperty ;
            rdfs:comment "The street name and civic number of an Address of the Agent."@en ;
            rdfs:label "street address"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Address (Agent)"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes locn:Address ;
            dcam:rangeIncludes rdfs:Literal .
 	   
@@ -711,35 +645,26 @@ dct:issued rdf:type owl:DatatypeProperty ;
            rdfs:comment "This property MAY be used to describe the date of the latest assessment procedure."@en ;
            rdfs:label "assessment date"@en  ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Assessment. Its range is rdfs:Literal typed as xsd:date or xsd:dateTime. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes mobilitydcatap:Assessment ;
            dcam:rangeIncludes rdfs:Literal .
 		   
-###  http://xmlns.com/foaf/0.1/#term_firstName
+###  http://xmlns.com/foaf/0.1/firstName  
 foaf:firstName rdf:type owl:DatatypeProperty ;
            rdfs:comment "If the agent is of type person, this property SHOULD be used to specify the first name of the Agent, see section § 7. Agent Types, Agent Roles and Contact Information."@en ;
            rdfs:label "first name"@en  ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Agent"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes locn:Address ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
+           dcam:domainIncludes foaf:Agent ;
            dcam:rangeIncludes rdfs:Literal .
 		   
-###  http://xmlns.com/foaf/0.1/#term_surname
+###  http://xmlns.com/foaf/0.1/surname  
 foaf:surname rdf:type owl:DatatypeProperty ;
            rdfs:comment "If the agent is of type person, this property SHOULD be used to specify the surname of the Agent, see section 7."@en ;
            rdfs:label "surname"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Agent"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes locn:Address ;
-           dcam:rangeIncludes rdfs:Literal .
-		   
-###   http://purl.org/dc/terms/identifier
-dct:identifier rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property MAY contain an identifier for the mobility data portal. Allows a unique identification of the individual portal and is used for referencing, e.g., when exchanging metadata between mobility data portals. This property SHOULD populated by the URI used within the RDF statement (via rdf:about). This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
-           rdfs:label "identifier"@en ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Catalogue. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes dcat:Catalog ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
+           dcam:domainIncludes foaf:Agent ;
            dcam:rangeIncludes rdfs:Literal .
 		   
 ###   http://purl.org/dc/terms/created
@@ -747,7 +672,7 @@ dct:created rdf:type owl:DatatypeProperty ;
            rdfs:comment "This property contains the date stamp (date and time) when the metadata entry was created for the first time. It SHOULD be generated by the system, whenever a platform user enters the metadata entry. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
            rdfs:label "creation date"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is a mandatory property to be used for Catalogue Record. Its range is rdfs:Literal typed as xsd:date or xsd:dateTime. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:CatalogRecord ;
            dcam:rangeIncludes rdfs:Literal .		   
 		   
@@ -758,7 +683,7 @@ mobilitydcatap:dataFormatNotes rdf:type owl:DatatypeProperty ;
            rdfs:isDefinedBy mobilitydcatap:;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Distributions."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Distribution ;
            dcam:rangeIncludes rdfs:Literal .		   
 		   
@@ -768,7 +693,7 @@ cnt:characterEncoding rdf:type owl:DatatypeProperty ;
            rdfs:label "character encoding"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Distributions."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dcat:Distribution ;
            dcam:rangeIncludes rdfs:Literal .				   
 		  
@@ -778,7 +703,7 @@ vcard:fn rdf:type owl:DatatypeProperty ;
            rdfs:label "name"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Kind."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes vcard:Kind ;
            dcam:rangeIncludes rdfs:Literal .				   
 		   
@@ -788,28 +713,19 @@ vcard:organization-name rdf:type owl:DatatypeProperty ;
            rdfs:label "affiliation"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Kind."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes vcard:Kind ;
            dcam:rangeIncludes rdfs:Literal .		   
 		   
 ###  http://www.w3.org/2000/01/rdf-schema#label
 rdfs:label rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property MAY be used to contain the full text of a Licence Document, as a free text. This MAY be used when there is no standard license that can be linked via property dct:identifier. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
-           rdfs:label "licence text"@en ;
+           rdfs:comment "This property MAY be used to contain the full text of a Licence Document as a free text, or to describe additional access, usage or licensing information for a Rights Statement. This property can be repeated for parallel language versions. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
+           rdfs:label "licence text / additional access information"@en ;
            vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Licence Document."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           skos:scopeNote "In mobilityDCAT-AP, this is an optional property for Licence Document and a recommended property for Rights Statement."@en ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dct:LicenseDocument ;
-           dcam:rangeIncludes rdfs:Literal .
-
-###  http://purl.org/dc/terms/identifier
-dct:identifier rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property contains the geographic identifier for the Location, e.g., the URI or other unique identifier in the context of the relevant gazetteer. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
-           rdfs:label "geographic identifier"@en ;
-           vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Location."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes dct:Location ;
+           dcam:domainIncludes dct:RightsStatement ;
            dcam:rangeIncludes rdfs:Literal .
 
 ###  http://www.w3.org/2004/02/skos/core#prefLabel
@@ -818,47 +734,29 @@ skos:prefLabel rdf:type owl:DatatypeProperty ;
            rdfs:label "geographic name"@en ;
            vs:term_status "stable" ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Location."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes dct:Location ;
            dcam:rangeIncludes rdfs:Literal .		   
-
-###   http://purl.org/dc/terms/conformsTo
-dct:conformsTo rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property describes the name of the mobility data standard. This property is necessary for the following CASE 1: A custom instance of mobilitydcatap:MobilityDataStandard is defined. Such custom instance is recommended when the mobility data standard is detailed out via properties owl:versionInfo and/or mobilitydcatap:schema. The property dct:conformsTo would then name the mobility data standard via a controlled vocabulary. In the alternative CASE 2, the name the mobility data standard is directly named as range of mobilitydcatap:MobilityDataStandard, again via the same controlled vocabulary."@en ;
-		   rdfs:label "standard name"@en ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes mobilitydcatap:MobilityDataStandard ;
-           dcam:rangeIncludes skos:Concept .
 
 ###   http://www.w3.org/2002/07/owl#versionInfo
 owl:versionInfo rdf:type owl:DatatypeProperty ;
            rdfs:comment "This property describes the version of the mobility data standard, as applied within the delivered content. A version might be, e.g., DATEX II v3.2. This information is provided in a textual format. To avoid ambiguity, only short version identifiers SHOULD be used, e.g., only  “3.2”, without redundant acronyms such as “v”, underscores etc."@en ;
 		   rdfs:label "version"@en ;
            skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Mobility Data Standard. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
            dcam:domainIncludes mobilitydcatap:MobilityDataStandard ;
            dcam:rangeIncludes rdfs:Literal .		   
 
-###   http://www.w3.org/ns/oa#hasBody
-oa:hasBody rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property MAY be used to describe any quality aspects regarding the delivered content, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes."@en ;
-           rdfs:label "quality annotation resource"@en ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Quality Annotation. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+###  https://www.w3.org/ns/oa#hasBody
+oa:hasBody a rdf:Property,
+           owl:ObjectProperty ;
+           rdfs:comment "This property MAY be used to describe the result of the latest assessment procedure in form of a URL, or any quality aspects regarding the delivered content. Textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model."@en ;
+           rdfs:label "annotation body"@en ;
+           skos:scopeNote "In mobilityDCAT-AP, this is an optional property for Assessment and Quality Annotation."@en ;
+           adms:status <http://publications.europa.eu/resource/authority/concept-status/CURRENT> ;
+           dcam:domainIncludes mobilitydcatap:Assessment ;
            dcam:domainIncludes dqv:QualityAnnotation ;
-           dcam:rangeIncludes rdfs:Literal .
-
-###  http://www.w3.org/2000/01/rdf-schema#label
-rdfs:label rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property MAY describes in a textual form any additional access, usage or licensing information, besides other information under classes dct:RightsStatement and dct:LicenseDocument. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
-           rdfs:label "Additional information for access and usage"@en ;
-           vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Rights Statement"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes dct:RightsStatement ;
-           dcam:rangeIncludes rdfs:Literal .
-		  
+           dcam:rangeIncludes rdfs:Resource .
 
 #################################################################
 #    Individuals
@@ -891,7 +789,7 @@ rdfs:label rdf:type owl:DatatypeProperty ;
 
 
 ###  https://w3id.org/mobilitydcatap/
-<https://w3id.org/mobilitydcatap/> rdf:type owl:NamedIndividual ;
+<https://w3id.org/mobilitydcat-ap/> rdf:type owl:NamedIndividual ;
                                    dct:conformsTo <http://data.europa.eu/r5r/> ,
                                                   <https://eur-lex.europa.eu/eli/reg/2008/1205/2008-12-24> ,
                                                   <https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/document/process-and-methodology-developing-semantic-agreements> ,
@@ -972,7 +870,7 @@ skos:notation skos:scopeNote "This property contains a string that is an identif
 
 skos:prefLabel skos:scopeNote "This property contains a preferred label of the Category. This property can be repeated for parallel language versions of the label - see § 8. Accessibility and Multilingual Aspects."@en .
 
-vcard:Kind skos:scopeNote "A description following the [VCARD-RDF] specification, e.g. to provide telephone number and e-mail address for a contact point. Note that the class vcard:Kind is the parent class for the four explicit types of vCards (vcard:Individual, vcard:Organization, vcard:Location, vcard:Group). This class is not explicitly associated with any property in [DCAT-AP-v2.0.1]. In [DCAT-AP-v2.0.1], this class is only used as the range of the recommended property ''dcat:contactPoint'' for class Dataset. In mobilityDCAT-AP, however, this property is removed, and any contact details are compiled under the Agent class, see § 7. Agent Types, Agent Roles and Agent Properties. Thus, this class SHOULD NOT be used but is kept for compatibility reasons with [DCAT-AP-v2.0.1]."@en .
+vcard:Kind skos:scopeNote "In mobilityDCAT-AP, this class is used as the range of the recommended property dcat:contactPoint for class Dataset. Properties vcard:fn and vcard:hasEmail are mandatory when an instance of this class is present."@en .
 
 adms:versionNotes skos:scopeNote "This property contains a textual description of the differences between this version and a previous version of the dataset, as an addition to the property owl:versionInfo. This property can be repeated for parallel language versions of the version notes - see § 8. Accessibility and Multilingual Aspects."@en .
 


### PR DESCRIPTION
Issue #179

## Files changed

- `mobilitydcat-ap_v1.1.0.ttl` — Turtle serialisation
- `mobilitydcat-ap_v1.1.0.rdf` — RDF/XML serialisation  
- `mobilitydcat-ap_v1.1.0.jsonld` — JSON-LD serialisation

## Fixes applied to all three files

- Namespace `http://w3id.org/mobilitydcat-ap` → `https://w3id.org/mobilitydcat-ap` (issue #128)
- `adms:status` URI corrected: `resource/dataset/concept-status` → `resource/authority/concept-status`

## Additional fixes in TTL file

- Version metadata updated from 1.0.0 to 1.1.0
- `vann:preferredNamespaceUri` corrected to `https://w3id.org/mobilitydcat-ap#`
- Dates updated to 2025-01-17 (v1.1.0 release date)
- `dcat:downloadURL` updated to `releases/1.1.0/` with `https://`
- `adms:last` and `adms:prev` corrected to `https://` and 1.1.0/1.0.1 respectively
- `adms:versionNotes` updated with v1.1.0 change summary
- `dcam:domainIncludes` fixed on Agent properties (`locn:Address` → `foaf:Agent`)
- Duplicate property declarations merged: `dct:identifier`, `skos:inScheme`, `dct:conformsTo`, `oa:hasBody`, `rdfs:label`
- `foaf:depiction` moved inside ontology metadata block
- Individual URI fixed: `mobilitydcatap/` → `mobilitydcat-ap/`
- `vcard:Kind` scope note updated to reflect actual usage
- `oa:` prefix corrected to `http://` (was wrongly `https://`)