### PR TITLE
CI: Add ReSpec validation and build artefact workflow for drafts/latest

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,79 @@
+name: Validate spec — ReSpec + W3C markup
+
+# Runs on every push to gh-pages to 'drafts/latest/**' path.
+# No deployment — this is a testing tool and artefacts builder only.
+
+on:
+  push:
+    branches: [gh-pages]
+    paths:  # only run when these change
+      - 'drafts/latest/**'
+  workflow_dispatch:
+
+jobs:
+  validate-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5  # avoids runaway jobs
+    permissions:
+      contents: write   # required by peaceiris/actions-gh-pages
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Generate ontology serializations
+        run: |
+          pip install rdflib
+          (cd drafts/latest/scripts && bash serialise-all.sh)
+
+      - name: Copy static files to dist
+        run: |
+          mkdir -p dist/tables dist/examples dist/figures dist/js dist/shaclShapes
+
+          # Ontology source
+          cp drafts/latest/mobilitydcat-ap.rdf    dist/ 2>/dev/null || true
+          cp drafts/latest/mobilitydcat-ap.ttl    dist/ 2>/dev/null || true
+          cp drafts/latest/mobilitydcat-ap.jsonld dist/ 2>/dev/null || true
+
+          # Example files
+          cp drafts/latest/examples/*.rdf     dist/examples/ 2>/dev/null || true
+          cp drafts/latest/examples/*.ttl     dist/examples/ 2>/dev/null || true
+          cp drafts/latest/examples/*.jsonld  dist/examples/ 2>/dev/null || true
+          cp drafts/latest/examples/*.xml     dist/examples/ 2>/dev/null || true
+
+          # Assets
+          cp -r drafts/latest/figures/.     dist/figures/     2>/dev/null || true
+          cp -r drafts/latest/shaclShapes/. dist/shaclShapes/ 2>/dev/null || true
+
+      - name: Install respec globally
+        # spec-prod installs respec locally via pnpm but the shell it spawns
+        # to run the build cannot find it. A global install makes it available
+        # system-wide regardless of what pnpm does with PATH.
+        run: npm install -g respec@36.0.0
+
+      - name: Validate spec with ReSpec + W3C checker
+        uses: w3c/spec-prod@v2
+        continue-on-error: true
+        with:
+          TOOLCHAIN: respec
+          SOURCE: drafts/latest/index.html
+          DESTINATION: dist/index.html
+          VALIDATE_INPUT_MARKUP: true
+          VALIDATE_MARKUP: true
+          # Disabled until this issue is resolved (the validation tool is not compatible with node.js 24)
+          # See: https://github.com/w3c/spec-prod/issues/222
+          # VALIDATE_LINKS: true
+
+      - name: Copy built index.html into dist
+        # spec-prod writes its output to a sibling directory (<repo>.common/dist/),
+        # not to the workspace dist/. Copy it back so peaceiris picks up a complete dist/.
+        run: cp "${GITHUB_WORKSPACE}.common/dist/index.html" dist/index.html
+
+      - name: List dist contents
+        run: find dist/ -type f | sort
+
+      - name: Upload built spec as artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spec-built
+          path: dist/


### PR DESCRIPTION
## Summary

Adds `.github/workflows/validate.yml`, a CI workflow that runs on every push to `gh-pages` (and on manual dispatch) to
validate the spec and produce a downloadable build artefact. 

At this moment it builds only the **`drafts/latest` version**.

**What the workflow does:**

1. Generates ontology serialisations (`.ttl`, `.jsonld`) from the source `.rdf` via `rdflib` / `serialise-all.sh`
2. Assembles static files (ontology, examples, figures, SHACL shapes) into `dist/`
3. Renders `drafts/latest/index.html` with ReSpec and validates markup using `w3c/spec-prod@v2`
4. Copies the rendered `index.html` back into `dist/` (spec-prod writes output to a sibling directory outside the
workspace)
5. Uploads `dist/` as a downloadable artefact (`spec-built`)

**Known limitation:** `VALIDATE_LINKS` is currently disabled due to an incompatibility between the W3C validation tool
and Node.js 24 — see w3c/spec-prod#222. It will be re-enabled once that issue is resolved upstream.

## Test plan

- [x] Workflow runs without error on push to `gh-pages`
- [x] `spec-built` artefact is available for download in the Actions tab
- [x] Rendered `index.html` in the artefact is a valid, fully processed ReSpec document
