### PR TITLE
[v3.0.0] SHACL Add deprecateduris file (issue #196)

### DIFF
--- a/drafts/latest/shaclShapes/mobilitydcat-ap-deprecateduris.ttl
+++ b/drafts/latest/shaclShapes/mobilitydcat-ap-deprecateduris.ttl
@@ -1,0 +1,118 @@
+@prefix : <https://w3id.org/mobilitydcat-ap/drafts/latest#> .
+@prefix mobilitydcatap: <https://w3id.org/mobilitydcat-ap#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+#-------------------------------------------------------------------------
+# mobilityDCAT-AP 3.0.0 — Deprecated URIs
+#
+# All shapes use sh:Warning: legacy catalogues remain valid while authors
+# are guided to the current term.
+#
+# SECTION A.2 — Properties deprecated by mobilityDCAT-AP
+#   Present in mobilityDCAT-AP v1.1.0, deprecated in v3.0.0 (spec Appendix A.2):
+#     Catalogue              dct:isPartOf
+#     Catalogue Record       dct:created
+#     Dataset                dct:isVersionOf
+#     Distribution           mobilitydcatap:grammar
+#     Licence Document       dct:identifier
+#     Licence Document       rdfs:label
+#     Mobility Data Standard mobilitydcatap:schema
+#
+# URI MIGRATIONS (mobility classes; alignment section of the change log)
+#     Mobility Data Standard owl:versionInfo -> dcat:version
+#
+# INHERITED (NOT restated — covered by DCAT-AP v3 deprecateduris.ttl,
+# loaded/imported alongside):
+#     dct:PeriodOfTime  schema:startDate / schema:endDate -> dcat:*
+#     dcat:Dataset      dct:hasVersion -> dcat:hasVersion
+#     dcat:Dataset      owl:versionInfo -> dcat:version
+#     dcat:Distribution adms:status (codelist change DCAT-AP 2.1 -> 3.0)
+#   NOTE: dcat:Dataset dct:isVersionOf is also flagged by DCAT-AP, but is
+#   listed in mobilityDCAT-AP Appendix A.2, so it is encoded here with the
+#   mobilityDCAT-AP message (use dcat:hasVersion). This intentionally
+#   overlaps the DCAT-AP shape.
+#-------------------------------------------------------------------------
+#=========================================================================
+# A.2 — Properties deprecated by mobilityDCAT-AP
+#=========================================================================
+
+#--- Catalogue: dct:isPartOf deprecated (inverse of dct:hasPart)
+:CatalogueDeprecation_Shape
+    a sh:NodeShape ;
+    rdfs:label "Catalogue deprecated properties (mobilityDCAT-AP 3.0.0)"@en ;
+    sh:targetClass dcat:Catalog ;
+    sh:property [
+        sh:path dct:isPartOf ;
+        sh:severity sh:Warning ;
+        sh:message "dct:isPartOf is deprecated in mobilityDCAT-AP 3.0.0 (inverse property); use dct:hasPart on the parent Catalogue."@en
+    ] .
+
+#--- Catalogue Record: dct:created deprecated
+:CatalogueRecordDeprecation_Shape
+    a sh:NodeShape ;
+    rdfs:label "Catalogue Record deprecated properties (mobilityDCAT-AP 3.0.0)"@en ;
+    sh:targetClass dcat:CatalogRecord ;
+    sh:property [
+        sh:path dct:created ;
+        sh:severity sh:Warning ;
+        sh:message "dct:created is deprecated in mobilityDCAT-AP 3.0.0; use dct:issued (#167)."@en
+    ] .
+
+#--- Dataset: dct:isVersionOf deprecated (inverse of dcat:hasVersion).
+#    Listed in Appendix A.2; encoded with mobilityDCAT-AP message.
+:DatasetDeprecation_Shape
+    a sh:NodeShape ;
+    rdfs:label "Dataset deprecated properties (mobilityDCAT-AP 3.0.0)"@en ;
+    sh:targetClass dcat:Dataset ;
+    sh:property [
+        sh:path dct:isVersionOf ;
+        sh:severity sh:Warning ;
+        sh:message "dct:isVersionOf is deprecated in mobilityDCAT-AP 3.0.0 (inverse property); use dcat:hasVersion on the related Dataset."@en
+    ] .
+
+#--- Distribution: mobilitydcatap:grammar deprecated
+:DistributionDeprecation_Shape
+    a sh:NodeShape ;
+    rdfs:label "Distribution deprecated properties (mobilityDCAT-AP 3.0.0)"@en ;
+    sh:targetClass dcat:Distribution ;
+    sh:property [
+        sh:path mobilitydcatap:grammar ;
+        sh:severity sh:Warning ;
+        sh:message "mobilitydcatap:grammar is deprecated in mobilityDCAT-AP 3.0.0; use dct:conformsTo (#90)."@en
+    ] .
+
+#--- Licence Document: dct:identifier and rdfs:label deprecated
+:LicenseDocumentDeprecation_Shape
+    a sh:NodeShape ;
+    rdfs:label "Licence Document deprecated properties (mobilityDCAT-AP 3.0.0)"@en ;
+    sh:targetClass dct:LicenseDocument ;
+    sh:property [
+        sh:path dct:identifier ;
+        sh:severity sh:Warning ;
+        sh:message "dct:identifier on dct:LicenseDocument is deprecated in mobilityDCAT-AP 3.0.0 (#165)."@en
+    ], [
+        sh:path rdfs:label ;
+        sh:severity sh:Warning ;
+        sh:message "rdfs:label on dct:LicenseDocument is deprecated in mobilityDCAT-AP 3.0.0 (#165)."@en
+    ] .
+
+#--- Mobility Data Standard: mobilitydcatap:schema deprecated;
+#    owl:versionInfo -> dcat:version (URI migration, mobility class)
+:MobilityDataStandardDeprecation_Shape
+    a sh:NodeShape ;
+    rdfs:label "Mobility Data Standard deprecated properties (mobilityDCAT-AP 3.0.0)"@en ;
+    sh:targetClass mobilitydcatap:MobilityDataStandard ;
+    sh:property [
+        sh:path mobilitydcatap:schema ;
+        sh:severity sh:Warning ;
+        sh:message "mobilitydcatap:schema is deprecated in mobilityDCAT-AP 3.0.0; use dct:conformsTo (#153)."@en
+    ], [
+        sh:path owl:versionInfo ;
+        sh:severity sh:Warning ;
+        sh:message "owl:versionInfo is deprecated on Mobility Data Standard; use dcat:version."@en
+    ] .


### PR DESCRIPTION
## What this PR changes
Adds `mobilitydcat-ap-deprecateduris.ttl` — SHACL `sh:Warning` shapes that flag use of properties deprecated by mobilityDCAT-AP, so legacy catalogues stay valid while authors are guided to the current term.

## Migration plan
Part of #207 — deprecations layer.

## Closes
Closes #196

## Reference
Implements spec Appendix A.2 — "Properties deprecated from previous version of mobilityDCAT-AP", one shape per row.

## Decision implemented (#196)
Per @peterlubrich / @marioscrock:
- Deprecated (in v1.1.0, not in v3.0.0; A.2) → encoded here as `sh:Warning`.
- Not used (DCAT-AP elements we don't profile; A.3) → not encoded (we cannot deprecate terms still valid in DCAT-AP).
- Term "removed" dropped.

## Shapes — one per A.2 row
| A.2 Class | Property | Replacement | Issue |
|---|---|---|---|
| Catalogue | dct:isPartOf | dct:hasPart (parent) | inverse policy |
| Catalogue Record | dct:created | dct:issued | #167 |
| Dataset | dct:isVersionOf | dcat:hasVersion (related) | inverse policy |
| Distribution | mobilitydcatap:grammar | dct:conformsTo | #90 |
| Licence Document | dct:identifier | — | #165 |
| Licence Document | rdfs:label | — | #165 |
| Mobility Data Standard | mobilitydcatap:schema | dct:conformsTo | #153 |

Plus one URI migration on a mobility class (alignment section, not A.2): Mobility Data Standard `owl:versionInfo` → `dcat:version`.

## Inherited from DCAT-AP (deliberately not restated)
Covered by DCAT-AP v3's own `deprecateduris.ttl`, loaded alongside: PeriodOfTime `schema:startDate`/`endDate`; Dataset `dct:hasVersion`, `owl:versionInfo`; Distribution `adms:status` codelist change.

One intentional overlap: Dataset `dct:isVersionOf` is also flagged by DCAT-AP, but A.2 lists it as a mobilityDCAT-AP deprecation with a stronger message (use `dcat:hasVersion`, not migrate to `dcat:isVersionOf`), so it is encoded here on purpose.

## Verified open questions (from #196)
- `dct:isVersionOf` kept — A.2 lists it; changelog I.1 confirms it under "Deprecations of properties".
- `dct:hasVersion` is not a typo: 1.1.0 SHACL (`Dataset_Shape_hasVersion`) uses `sh:path dct:hasVersion`, so it is a real migration, handled upstream by DCAT-AP and not restated here.

## Scope / not in this PR
- [ ] `owl:imports` of DCAT-AP's `deprecateduris.ttl` — handled centrally in `imports.ttl` (Phase 1), not inside this file. Open question for @marioscrock below.
- [ ] "Not used" elements → Appendix A.3 documentation only (no SHACL).
- [ ] A.1 table inconsistencies (active tables still list deprecated props) — separate PR; may be Enterprise-Architect-generated (confirm with @lcomet).
- [ ] Dropping the non-resolving file-level `owl:Ontology` IRI from the two existing shape files — flagged in #196 as a separate fix.

## Question for reviewers
@marioscrock — for loading the upstream DCAT-AP deprecations (PeriodOfTime, Dataset versioning, adms:status): do you prefer we `owl:imports` DCAT-AP's `deprecateduris.ttl` from our central `imports.ttl`, or load it via the validator config? Either way this file stays mobility-only; I just want to confirm the import approach before wiring Phase 1.

## Checklist
- [x] File parses (Turtle valid)
- [x] One shape per A.2 row
- [x] Only deprecated terms encoded; not-used terms excluded
- [x] Each shape traces to A.2 / an issue
- [x] Linked to #207 and closes #196