### PR TITLE
[v3.0.0] SHACL Add imports file (issue #207)

### DIFF
--- a/drafts/latest/shaclShapes/imports.ttl
+++ b/drafts/latest/shaclShapes/imports.ttl
@@ -1,0 +1,40 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+#-------------------------------------------------------------------------
+# mobilityDCAT-AP 3.0.0 — Ontology imports
+#
+# Provides the imports implicitly required by reusing terms from the base
+# vocabularies in the mobilityDCAT-AP application profile. URLs point to RDF
+# serialisations (Turtle / RDF-XML), since not all ontology IRIs implement
+# content negotiation; the RDF format is required for the ISA testbed (ITB)
+# validator. All URLs verified to return 200 + an RDF content type, and
+# resolved to their final location (no reliance on redirects).
+# Vocabularies follow the namespace table in spec section 5.4. SPDX and PROV
+# are intentionally NOT imported: spdx:Checksum and prov:Activity /
+# prov:Attribution are "not used from DCAT-AP" (see Appendix A.3).
+# ODRL is excluded (as in DCAT-AP): the Concept shape applies to all
+# skos:Concept instances and ODRL's skos:Concepts do not comply.
+# NOTE: locn and adms are served by w3.org under "legacy_" paths.
+#-------------------------------------------------------------------------
+
+<https://w3id.org/mobilitydcat-ap/imports>
+  rdf:type owl:Ontology ;
+  owl:imports <https://www.w3.org/ns/dcat2.ttl> ;
+  owl:imports <https://www.dublincore.org/2020/01/20/dublin_core_terms.ttl> ;
+  owl:imports <https://xmlns.com/foaf/spec/index.rdf> ;
+  owl:imports <https://www.w3.org/ns/legacy_locn.ttl> ;
+  owl:imports <https://www.w3.org/ns/org.ttl> ;
+  owl:imports <https://www.w3.org/ns/legacy_adms.ttl> ;
+  owl:imports <https://www.w3.org/2006/vcard/ns.ttl> ;
+  owl:imports <https://www.w3.org/ns/dqv.ttl> ;
+  owl:imports <https://www.w3.org/ns/oa.ttl> ;
+  owl:imports <https://www.w3.org/2011/content.rdf> ;
+  owl:imports <https://www.w3.org/2006/time.ttl> ;
+  owl:imports <https://schema.org/version/30.0/schemaorg-current-https.ttl> ;
+  # DCAT-AP's own deprecateduris.ttl — pulls in the upstream (PeriodOfTime,
+  # Dataset versioning, adms:status) deprecations so they are not restated
+  owl:imports <https://raw.githubusercontent.com/SEMICeu/DCAT-AP/refs/heads/master/releases/3.0.1/html/shacl/deprecateduris.ttl>
+  .


### PR DESCRIPTION
## What this PR adds
`imports.ttl` wiring the base-vocabulary `owl:imports` for the v3 SHACL (dcat, dcterms, foaf, locn, org, adms, vcard, dqv, oa, cnt, time, schema.org), plus DCAT-AP's own `deprecateduris.ttl` so upstream deprecations are inherited (not restated).

Part of #207 (Phase 1).

All import URLs return 200 + an RDF content type, resolved to final locations (https, w3.org `legacy_` paths for locn/adms, schema.org pinned at 30.0). File parses as valid Turtle.

## Question before merge
@marioscrock — should base-vocabulary imports be wired here via `owl:imports` (this file), or loaded through the ITB validator config instead? This PR takes the `owl:imports` approach. Happy to switch to validator-config if you prefer. Also: does our ITB setup follow `owl:imports` by default, or does that need enabling? Holding merge until confirmed.