### PR TITLE
Align ReSpec ED status with manual Status section

### DIFF
--- a/drafts/latest/config.js
+++ b/drafts/latest/config.js
@@ -38,7 +38,8 @@ var respecConfig = {
     }
     ],
     errata:"https://github.com/mobilityDCAT-AP/mobilityDCAT-AP/issues?q=is%3Aissue+label%3Aerrata",
-    specStatus: "unofficial",
+// ED stands for Editor's draft, see other possible follow-up statuses: https://respec.org/docs/#specStatus
+    specStatus: "ED",
 // Avoid Latest published version: to be automatically generated with the wrong URI
     latestVersion: "https://w3id.org/mobilitydcat-ap/drafts/latest/",
     shortName: "mobilitydcat-ap",

--- a/drafts/latest/index.html
+++ b/drafts/latest/index.html
@@ -136,7 +136,7 @@
 
 <h2>Status</h2>
 
-<p>This application profile has the status NAPCORE Recommendation published at 2025-12-xx.</p>
+<p>This application profile is currently published as an Editor's Draft and may change before publication as a NAPCORE Recommendation.</p>
 
 <p>Information about the process and the decisions involved in the creation of this specification are consultable at the Changelog - see <a class="no-secRef" href="#change-log"></a>.</p>
 


### PR DESCRIPTION
## Summary
- set specStatus to ED in drafts/latest/config.js
- align the manual Status paragraph in drafts/latest/index.html with Editor's Draft wording
- keeps ReSpec boilerplate and authored status text consistent