### PR TITLE
Fix malformed HTML markup in latest draft

### DIFF
--- a/drafts/latest/index.html
+++ b/drafts/latest/index.html
@@ -989,7 +989,7 @@ This work was elaborated by the NAPCORE Sub-Working Group (SWG) 4.4 [[NAPCORE-Me
 <li>OK = this element can remain from the original</li>
 <li>PROPOSAL = this element can remain from the original; however, a proposal is given following the usage notes of mobilityDCAT-AP</li>
 <li>MODIFIED = changed element</li>
-<li>ADDED = new element</p></li>
+<li>ADDED = new element</li>
 </ul>
 
 <p>The above RDF/XML example population was further formatted as a TTL file. Lastly, a reduced example population is provided, only considering mandatory elements from mobilityDCAT-AP v3.0.0.</p>

--- a/drafts/latest/tables/dcat-ap-not-used-classes.html
+++ b/drafts/latest/tables/dcat-ap-not-used-classes.html
@@ -96,7 +96,7 @@
 <p>In DCAT-AP-v3.0.1, this class is only used as the range of the optional properties 
   <a href="https://semiceu.github.io/DCAT-AP/releases/3.0.1-draft/#Distribution.compressionformat"><code>dcat:compressFormat</code></a>,
     <a href="https://semiceu.github.io/DCAT-AP/releases/3.0.1-draft/#Distribution.mediatype"><code>dcat:mediaType</code></a> and
-    <a href="https://semiceu.github.io/DCAT-AP/releases/3.0.1-draft/#Distribution.packagingformat"><code>dcat:packageFormat"</code></a>.
+    <a href="https://semiceu.github.io/DCAT-AP/releases/3.0.1-draft/#Distribution.packagingformat"><code>dcat:packageFormat</code></a>.
   of class Distribution. 
   In mobilityDCAT-AP, these properties are not used. So, the class is without function in mobilityDCAT-AP.</p>
 </td>

--- a/drafts/latest/tables/properties-for-dataset-series.html
+++ b/drafts/latest/tables/properties-for-dataset-series.html
@@ -163,7 +163,8 @@ Information about the dataset series as a free-text description.</p>
 </td>
 <td valign=top>
   <p>A corresponding <a href="#vocab-mobility-theme">controlled vocabulary</a> is provided.</p>
- <td valign=top>
+</td>
+<td valign=top>
 <p>P</p>
 </td>
 </tr>

--- a/drafts/latest/tables/properties-for-dataset.html
+++ b/drafts/latest/tables/properties-for-dataset.html
@@ -608,7 +608,7 @@ or other identifier systems such as [[DataCite-Metadata-Schema]], [[DOI]], or [[
 <tr class="property" id="dataset-rights-holder">
 <td valign=top>
 <p>+rights holder</p>
-<p><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#rightsHolder"><code>dct:rightsHolder</code></p>
+<p><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#rightsHolder"><code>dct:rightsHolder</code></a></p>
 </td>
 <td valign=top>
 <p><a href="#class-agent"><code>foaf:Agent</code></a></p>
@@ -784,7 +784,7 @@ or other identifier systems such as [[DataCite-Metadata-Schema]], [[DOI]], or [[
 <p>A textual description of the differences between this version and a previous version of the dataset.</p>
 </td>
 <td valign=top>
- <p>This property should be an addition to the property <a href="#dataset-version"><code><code>dcat:version</code></a>.</p>
+ <p>This property should be an addition to the property <a href="#dataset-version"><code>dcat:version</code></a>.</p>
  <p>This property can be repeated for parallel language versions of the version notes - see <a class="no-secRef" href="#accessibility-and-multilingual-aspects"></a>.</p>
 </td>
 <td valign=top>

--- a/drafts/latest/tables/properties-for-distribution.html
+++ b/drafts/latest/tables/properties-for-distribution.html
@@ -101,7 +101,7 @@
 <tr class="property" id="distribution-character-encoding">
 <td valign=top>
 <p>+character encoding</p>
-<p><a href="http://www.w3.org/2011/content#characterEncoding"><code>cnt:characterEncoding</code></p>
+<p><a href="http://www.w3.org/2011/content#characterEncoding"><code>cnt:characterEncoding</code></a></p>
 </td>
 <td valign=top>
 <p><a href="#class-literal"><code>rdfs:Literal</code></a></p>


### PR DESCRIPTION
Second batch of fixes from my review (see #232 for the functional-bug batch and issue #186 for context). This PR repairs six malformed-HTML defects in `drafts/latest/`, they are all invisible or mildly corrupting in the rendered page, none semantic.

## Proposed Fixes

1. **Missing `</a>`** after the `dct:rightsHolder` link — `tables/properties-for-dataset.html` (rights holder row).
2. **Doubled `<code><code>`** around `dcat:version` — `tables/properties-for-dataset.html` (version notes row).
3. **Unclosed `<td>`** in the mobility-theme row — `tables/properties-for-dataset-series.html`: the usage-note cell was never closed before the next cell opened.
4. **Missing `</a>`** after the `cnt:characterEncoding` link — `tables/properties-for-distribution.html`.
5. **Stray quotation mark** inside the code tag: `dcat:packageFormat"` — `tables/dcat-ap-not-used-classes.html`.
6. **Orphaned `</p>`** in the change-log legend: `<li>ADDED = new element</p></li>` — `index.html`.

Each change is a one- or two-character repair; no wording, definitions, or links were altered beyond closing/removing the broken tags.