### PR TITLE
Fix critical ontology defects in draft serializations (namespace, oa:hasBody, rdfs:label)

### DIFF
--- a/drafts/latest/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_minimum population_240205.ttl
+++ b/drafts/latest/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_minimum population_240205.ttl
@@ -8,7 +8,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix eli: <http://data.europa.eu/eli/ontology#> .
-@prefix geodcatap: <http://www.w3.org/ns/geodcat#> .
+@prefix geodcatap: <http://data.europa.eu/930/> .
 
 <https://trafficdata.se/>
   a dcat:Catalog ;

--- a/drafts/latest/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.jsonld
+++ b/drafts/latest/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.jsonld
@@ -175,7 +175,7 @@
         "@id": "http://publications.europa.eu/resource/authority/data-theme/TRAN"
       }
     ],
-    "http://www.w3.org/ns/geodcat#referenceSystem": [
+    "http://data.europa.eu/930/referenceSystem": [
       {
         "@id": "http://www.opengis.net/def/crs/EPSG/0/4326"
       }

--- a/drafts/latest/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.ttl
+++ b/drafts/latest/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.ttl
@@ -8,7 +8,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix eli: <http://data.europa.eu/eli/ontology#> .
-@prefix geodcatap: <http://www.w3.org/ns/geodcat#> .
+@prefix geodcatap: <http://data.europa.eu/930/> .
 
 <https://trafficdata.se/>
   a dcat:Catalog ;

--- a/drafts/latest/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.xml
+++ b/drafts/latest/examples/SE NAP_dataset_expressed in mobilityDCAT-AP_original population_240205.xml
@@ -4,7 +4,7 @@
    xmlns:dcat="http://www.w3.org/ns/dcat#"
    xmlns:dcatap="http://data.europa.eu/r5r/"
    xmlns:foaf="http://xmlns.com/foaf/0.1/"
-   xmlns:geodcatap="http://www.w3.org/ns/geodcat#"
+   xmlns:geodcatap="http://data.europa.eu/930/"
    xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:vcard="http://www.w3.org/2006/vcard/ns#"

--- a/drafts/latest/mobilitydcat-ap.jsonld
+++ b/drafts/latest/mobilitydcat-ap.jsonld
@@ -625,7 +625,7 @@
     ]
   },
   {
-    "@id": "http://www.w3.org/ns/geodcat#referenceSystem",
+    "@id": "http://data.europa.eu/930/referenceSystem",
     "@type": [
       "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
       "http://www.w3.org/2002/07/owl#ObjectProperty"
@@ -648,7 +648,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
-        "@id": "http://www.w3.org/ns/geodcat#"
+        "@id": "http://data.europa.eu/930/"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [

--- a/drafts/latest/mobilitydcat-ap.rdf
+++ b/drafts/latest/mobilitydcat-ap.rdf
@@ -158,12 +158,12 @@
     <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/dqv#QualityAnnotation"/>
     <dcam:rangeIncludes rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.w3.org/ns/geodcat#referenceSystem">
+  <rdf:Description rdf:about="http://data.europa.eu/930/referenceSystem">
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
     <rdfs:comment xml:lang="en">The spatial reference system used in the dataset. Spatial reference systems SHOULD be specified using URIs from the EPSG coordinate reference systems register operated by OGC.</rdfs:comment>
     <rdfs:label xml:lang="en">reference system</rdfs:label>
-    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/geodcat#"/>
+    <rdfs:isDefinedBy rdf:resource="http://data.europa.eu/930/"/>
     <vs:term_status>stable</vs:term_status>
     <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Dataset.</skos:scopeNote>
     <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>

--- a/drafts/latest/mobilitydcat-ap.ttl
+++ b/drafts/latest/mobilitydcat-ap.ttl
@@ -8,7 +8,7 @@
 @prefix dqv: <http://www.w3.org/ns/dqv#> .
 @prefix eli: <http://data.europa.eu/eli/ontology#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix geodcatap: <http://www.w3.org/ns/geodcat#> .
+@prefix geodcatap: <http://data.europa.eu/930/> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 @prefix mobilitydcatap: <https://w3id.org/mobilitydcat-ap#> .
 @prefix oa: <http://www.w3.org/ns/oa#> .
@@ -281,12 +281,14 @@ foaf:workplaceHomepage a rdf:Property,
 ###   http://www.w3.org/ns/oa#hasBody
 oa:hasBody a rdf:Property,
            owl:ObjectProperty ;
-           rdfs:comment "This property MAY be used to describe the result of the latest assessment procedure, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes."@en ;
-           rdfs:label "assessment result"@en ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Assessment. "@en ;
+           rdfs:comment "This property MAY be used to describe the result of the latest assessment procedure (class Assessment) or any quality aspects regarding the delivered content (class Quality Annotation), in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes."@en ;
+           rdfs:label "has body"@en ;
+           skos:scopeNote "In mobilityDCAT-AP, this is an optional property (named 'assessment result') to be used for Assessment. "@en ,
+                          "In mobilityDCAT-AP, this is an optional property (named 'quality annotation resource') to be used for Quality Annotation. "@en ;
            adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes mobilitydcatap:Assessment ;
-           dcam:rangeIncludes rdfs:Resource .	   		   	   
+           dcam:domainIncludes mobilitydcatap:Assessment ,
+                               dqv:QualityAnnotation ;
+           dcam:rangeIncludes rdfs:Resource .
 		   
 ###   http://www.w3.org/ns/adms#identifier 
 adms:identifier a rdf:Property,
@@ -355,7 +357,7 @@ mobilitydcatap:georeferencingMethod a rdf:Property,
            dcam:domainIncludes dcat:Dataset ;
            dcam:rangeIncludes skos:Concept .
 		   
-###  http://www.w3.org/ns/geodcat#referenceSystem
+###  http://data.europa.eu/930/referenceSystem
 geodcatap:referenceSystem a rdf:Property,
            owl:ObjectProperty ;
            rdfs:comment "The spatial reference system used in the dataset. Spatial reference systems SHOULD be specified using URIs from the EPSG coordinate reference systems register operated by OGC."@en ;
@@ -783,12 +785,7 @@ vcard:organization-name rdf:type owl:DatatypeProperty ;
            dcam:rangeIncludes rdfs:Literal .		   
 		   
 ###  http://www.w3.org/2000/01/rdf-schema#label
-rdfs:label rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property MAY be used to contain the full text of a Licence Document, as a free text. This MAY be used when there is no standard license that can be linked via property dct:identifier. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
-           rdfs:label "licence text"@en ;
-           vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Licence Document."@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+rdfs:label skos:scopeNote "In mobilityDCAT-AP, this is an optional property (named 'licence text') to be used for Licence Document. It MAY be used to contain the full text of a Licence Document, as a free text, when there is no standard license that can be linked via property dct:identifier. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
            dcam:domainIncludes dct:LicenseDocument ;
            dcam:rangeIncludes rdfs:Literal .
 
@@ -830,22 +827,8 @@ owl:versionInfo rdf:type owl:DatatypeProperty ;
            dcam:domainIncludes mobilitydcatap:MobilityDataStandard ;
            dcam:rangeIncludes rdfs:Literal .		   
 
-###   http://www.w3.org/ns/oa#hasBody
-oa:hasBody rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property MAY be used to describe any quality aspects regarding the delivered content, in form of a URL linking to further details or results. Alternatively, textual information MAY be provided using the Embedded Textual Body construction of the Web Annotation Data Model [Web-Annotation-Data-Model], which allows to specify text formats and languages which might be relevant for multilingual purposes."@en ;
-           rdfs:label "quality annotation resource"@en ;
-           skos:scopeNote "In mobilityDCAT-AP, this is an optional property to be used for Quality Annotation. "@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
-           dcam:domainIncludes dqv:QualityAnnotation ;
-           dcam:rangeIncludes rdfs:Literal .
-
 ###  http://www.w3.org/2000/01/rdf-schema#label
-rdfs:label rdf:type owl:DatatypeProperty ;
-           rdfs:comment "This property MAY describes in a textual form any additional access, usage or licensing information, besides other information under classes dct:RightsStatement and dct:LicenseDocument. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
-           rdfs:label "Additional information for access and usage"@en ;
-           vs:term_status "stable" ;
-           skos:scopeNote "In mobilityDCAT-AP, this is a recommended property to be used for Rights Statement"@en ;
-           adms:status <http://publications.europa.eu/resource/dataset/concept-status/CURRENT> ;
+rdfs:label skos:scopeNote "In mobilityDCAT-AP, this is a recommended property (named 'additional information for access and usage') to be used for Rights Statement. It MAY describe in a textual form any additional access, usage or licensing information, besides other information under classes dct:RightsStatement and dct:LicenseDocument. This property can be repeated for parallel language versions of the name - see § 8. Accessibility and Multilingual Aspects. This property is analogue to an addition by [GEODCAT-AP-v2.0.0]."@en ;
            dcam:domainIncludes dct:RightsStatement ;
            dcam:rangeIncludes rdfs:Literal .
 		  

--- a/drafts/latest/mobilitydcat-ap.xml
+++ b/drafts/latest/mobilitydcat-ap.xml
@@ -285,12 +285,12 @@
     <dcam:domainIncludes rdf:resource="http://www.w3.org/ns/locn#Address"/>
     <dcam:rangeIncludes rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.w3.org/ns/geodcat#referenceSystem">
+  <rdf:Description rdf:about="http://data.europa.eu/930/referenceSystem">
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
     <rdfs:comment xml:lang="en">The spatial reference system used in the dataset. Spatial reference systems SHOULD be specified using URIs from the EPSG coordinate reference systems register operated by OGC.</rdfs:comment>
     <rdfs:label xml:lang="en">reference system</rdfs:label>
-    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/geodcat#"/>
+    <rdfs:isDefinedBy rdf:resource="http://data.europa.eu/930/"/>
     <vs:term_status>stable</vs:term_status>
     <skos:scopeNote xml:lang="en">In mobilityDCAT-AP, this is a recommended property to be used for Dataset.</skos:scopeNote>
     <adms:status rdf:resource="http://publications.europa.eu/resource/dataset/concept-status/CURRENT"/>

--- a/drafts/latest/shaclShapes/mobilitydcat-ap-shacl-ranges.ttl
+++ b/drafts/latest/shaclShapes/mobilitydcat-ap-shacl-ranges.ttl
@@ -1,6 +1,6 @@
 @prefix : <https://w3id.org/mobilitydcat-ap/drafts/latest#> .
 @prefix mobilitydcatap: <https://w3id.org/mobilitydcat-ap#> .
-@prefix geodcatap: <http://www.w3.org/ns/geodcat#> .
+@prefix geodcatap: <http://data.europa.eu/930/> .
 @prefix eli: <http://data.europa.eu/eli/ontology#> .
 
 @prefix adms: <http://www.w3.org/ns/adms#> .

--- a/drafts/latest/shaclShapes/mobilitydcat-ap-shacl.ttl
+++ b/drafts/latest/shaclShapes/mobilitydcat-ap-shacl.ttl
@@ -1,6 +1,6 @@
 @prefix : <https://w3id.org/mobilitydcat-ap/drafts/latest#> .
 @prefix mobilitydcatap: <https://w3id.org/mobilitydcat-ap#> .
-@prefix geodcatap: <http://www.w3.org/ns/geodcat#> .
+@prefix geodcatap: <http://data.europa.eu/930/> .
 @prefix eli: <http://data.europa.eu/eli/ontology#> .
 
 @prefix adms: <http://www.w3.org/ns/adms#> .


### PR DESCRIPTION
Third batch from the v3 draft review (see #232, #233 for the ReSpec-page batches). This one addresses three defects in `drafts/latest/mobilitydcat-ap.ttl` that affect machine consumers of the ontology, namely reasoners, validators, and any tooling that imports it.

## 1. Wrong GeoDCAT-AP namespace (all RDF artifacts)

The `geodcatap:` prefix was bound to `http://www.w3.org/ns/geodcat#`, a URI that does not exist (returns 404). GeoDCAT-AP's actual namespace is `http://data.europa.eu/930/`, which the specification's own namespaces table already declares. As a result, `geodcatap:referenceSystem` minted a URI that no GeoDCAT-AP tool recognizes.

Fixed consistently across the four ontology serializations (`.ttl`, `.rdf`, `.xml`, `.jsonld`), both SHACL shape files, and the four example files that used the wrong URI. Verified against the live GeoDCAT-AP 3.0.0 page (`data.europa.eu/930/referenceSystem` exists there).

## 2. Contradictory double declaration of `oa:hasBody` (issue #230)

The TTL declared `oa:hasBody` twice: once as `owl:ObjectProperty` with range `rdfs:Resource` (Assessment) and once as `owl:DatatypeProperty` with range `rdfs:Literal` (Quality Annotation), with two different `rdfs:label`s. Merged, this makes the property simultaneously an object and a datatype property, an OWL contradiction, and is the serialized form of the range conflict resolved in #230 (`rdfs:Resource` for both).

Now a single `owl:ObjectProperty` declaration with `dcam:rangeIncludes rdfs:Resource`, `dcam:domainIncludes` both classes, a neutral label, and one `skos:scopeNote` per usage.

## 3. `rdfs:label` redeclared as a datatype property with profile-specific labels

Two blocks retyped the core RDFS term `rdfs:label` as `owl:DatatypeProperty` and gave it global `rdfs:label`/`rdfs:comment` values ('licence text', 'Additional information for access and usage'). Any tool importing the ontology would then display `rdfs:label` itself under those names. The Licence Document and Rights Statement usage documentation is preserved as `skos:scopeNote` annotations; the hijacking typings, labels, and comments are removed.

## Validation

- All edited Turtle files re-parsed with rdflib (ontology: 720 → 709 triples; the delta is exactly the removed contradictory/duplicate statements).
- `oa:hasBody`: single type, single label, range `rdfs:Resource`, domains Assessment + QualityAnnotation.
- `rdfs:label`: only its legitimate `owl:AnnotationProperty` declaration remains.
- No occurrence of the old namespace remains anywhere in `drafts/latest/`.

## Note for reviewers

The `.rdf` / `.xml` / `.jsonld` serializations received only the mechanical namespace replacement — fixes 2 and 3 are in the Turtle file only, since hand-editing the other formats block-by-block is error-prone. The serializations were already out of sync before this PR (e.g. the `.rdf` still references `vocab-dcat-2` where the TTL has `vocab-dcat-3`), so a regeneration of all formats from the Turtle source is recommended as a follow-up regardless.