### PR TITLE
Fix fragment with spaces in revision-history section id

### DIFF
--- a/drafts/latest/index.html
+++ b/drafts/latest/index.html
@@ -125,7 +125,7 @@ It is compatible with the parallel specifications [[DCAT-AP-v3.0.1]] and [[GeoDC
 
 
 
-<section id="revision history">
+<section id="revision-history">
 
 <h3>Revision history</h3>
 


### PR DESCRIPTION
Fixes the last remaining item from #191.

`<section id="revision history">` in `drafts/latest/index.html` had a space in the `id`, which fails HTML validation (fragment identifiers with spaces). Replaced with a hyphen: `id="revision-history"`.

No other markup in the repo referenced `#revision history` as an anchor, so no links needed updating.

## Context
The other five categories reported in #191 turned out to already be fixed (by other PRs).