### PR TITLE
Various alignments with the recent DCAT-AP v3.0.1 spec - see issue #197

### DIFF
--- a/drafts/latest/config.js
+++ b/drafts/latest/config.js
@@ -119,6 +119,14 @@ var respecConfig = {
       }
       ]
     },
+    {
+	  key: "Previous version:",
+	  data: [ { value : "https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/", href : "https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/1.1.0/" } ]
+	},
+    {
+	  key: "This version:",
+	  data: [ { value : "https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/3.0.0/", href : "https://mobilitydcat-ap.github.io/mobilityDCAT-AP/releases/3.0.0/" } ]
+	}       
   ],
     wg: "NAPCORE Sub-Working Group (SWG) 4.4",
     wgURI: "https://github.com/mobilityDCAT-AP/",

--- a/drafts/latest/tables/properties-for-distribution.html
+++ b/drafts/latest/tables/properties-for-distribution.html
@@ -432,7 +432,7 @@ In contrast, the property <a href="#distribution-description"><code>dct:descript
 <p><a href="#class-rights-statement"><code>dct:RightsStatement</code></a></p>
 </td>
 <td valign=top>
-<p>1..1</p>
+<p>1..n</p>
 </td>
 <td valign=top>
 <p>A statement that specifies rights associated with the distribution. In particular, a statement about the intellectual property rights (IPR). As a minimum, it should include an information on the type of conditions for access and usage.</p>

--- a/drafts/latest/tables/properties-for-distribution.html
+++ b/drafts/latest/tables/properties-for-distribution.html
@@ -432,7 +432,7 @@ In contrast, the property <a href="#distribution-description"><code>dct:descript
 <p><a href="#class-rights-statement"><code>dct:RightsStatement</code></a></p>
 </td>
 <td valign=top>
-<p>1..n</p>
+<p>1..*</p>
 </td>
 <td valign=top>
 <p>A statement that specifies rights associated with the distribution. In particular, a statement about the intellectual property rights (IPR). As a minimum, it should include an information on the type of conditions for access and usage.</p>


### PR DESCRIPTION
Based on Valentina's analysis on the recent changes in DCAT-P v3.0.1, see issue #197 
 
I am proposing two changes for mobilityDCAT-AP v3, considering the ReSpec page and the data model, see the comments below:

- Change 1: Change cardinality for property "rights" at class "Distribution"
- Change 2: Add links for previous and current version releases in the preamble